### PR TITLE
Pass keymaps as an argument to SELECT-FROM-MENU, instead of binding *MENU-MAP*

### DIFF
--- a/minor-mode/mpd/mpd.lisp
+++ b/minor-mode/mpd/mpd.lisp
@@ -423,14 +423,14 @@ Volume
 (defvar *mpd-volume-step* 5)
 
 (defun mpd-menu (title options keymap &optional initial-selection)
-  (let ((*menu-map* keymap))
-    (multiple-value-bind (choice selection)
-        (select-from-menu (current-screen) options title (or initial-selection
-                                                             0))
-      (cond
-        ((null choice)
-         (throw 'error "Abort."))
-        (t (values choice selection))))))
+  (multiple-value-bind (choice selection)
+      (select-from-menu (current-screen) options title
+                        (or initial-selection 0)
+                        keymap)
+    (cond
+      ((null choice)
+       (throw 'error "Abort."))
+      (t (values choice selection)))))
 
 (defun mpd-selected-item (menu)
   (nth (menu-state-selected menu) (menu-state-table menu)))
@@ -446,15 +446,8 @@ Volume
 (when (null *mpd-playlist-menu-map*)
   (setf *mpd-playlist-menu-map*
         (let ((m (make-sparse-keymap)))
-          (define-key m (kbd "C-p") 'menu-up)
-          (define-key m (kbd "Up") 'menu-up)
           (define-key m (kbd "k") 'menu-up)
-
-          (define-key m (kbd "C-n") 'menu-down)
-          (define-key m (kbd "Down") 'menu-down)
           (define-key m (kbd "j") 'menu-down)
-          (define-key m (kbd "C-g") 'menu-abort)
-          (define-key m (kbd "ESC") 'menu-abort)
 
           (define-key m (kbd "S-Up") (mpd-menu-action :mpd-playlist-move-up))
           (define-key m (kbd "S-Down") (mpd-menu-action :mpd-playlist-move-down))
@@ -509,15 +502,8 @@ Volume
 (when (null *mpd-browse-menu-map*)
   (setf *mpd-browse-menu-map*
         (let ((m (make-sparse-keymap)))
-          (define-key m (kbd "C-p") 'menu-up)
-          (define-key m (kbd "Up") 'menu-up)
           (define-key m (kbd "k") 'menu-up)
-
-          (define-key m (kbd "C-n") 'menu-down)
-          (define-key m (kbd "Down") 'menu-down)
           (define-key m (kbd "j") 'menu-down)
-          (define-key m (kbd "C-g") 'menu-abort)
-          (define-key m (kbd "ESC") 'menu-abort)
 
           (define-key m (kbd "RET") (mpd-menu-action :mpd-browse-add-and-quit))
           (define-key m (kbd "S-RET") (mpd-menu-action :mpd-browse-add))


### PR DESCRIPTION
This lets the mpd module make use of the changes I made in stumpwm/stumpwm#95.

Note that these changes are based on those in #9, making this a bit of a mess. I'm sorry for that.
