### PR TITLE
Compile the functions before the macro.

### DIFF
--- a/util/surfraw/macros.lisp
+++ b/util/surfraw/macros.lisp
@@ -14,3 +14,5 @@
                  (surfraw ,key (get-x-selection)))
               commands)))
     (cons 'progn (reverse commands))))
+
+(auto-define-surfraw-commands-from-elvis-list)

--- a/util/surfraw/surfraw.asd
+++ b/util/surfraw/surfraw.asd
@@ -7,6 +7,6 @@
   :license "GPLv3"
   :depends-on (#:stumpwm)
   :components ((:file "package")
-               (:file "macros" :depends-on ("package"))
-               (:file "surfraw" :depends-on ("macros"))))
+               (:file "surfraw" :depends-on ("package"))
+               (:file "macros" :depends-on ("surfraw"))))
 

--- a/util/surfraw/surfraw.lisp
+++ b/util/surfraw/surfraw.lisp
@@ -27,7 +27,6 @@
                          (split-string (run-shell-command "surfraw -elvi" :collect-output-p)
                                        '(#\Newline)))))
 
-(auto-define-surfraw-commands-from-elvis-list)
 ;;; Regular surfraw commands
 
 (defcommand surfraw (engine search)


### PR DESCRIPTION
One last thing, David: we need to compile the functions before the macro, otherwise surfraw-elvis-list is undefined during the expansion of auto-define-surfraw-commands-from-elvis-list.
