### PR TITLE
Fix wifi module

### DIFF
--- a/modeline/wifi/wifi.lisp
+++ b/modeline/wifi/wifi.lisp
@@ -49,16 +49,6 @@ prev-val."
                        nil)))
       (error "No wireless device found.")))
 
-(defun read-wifi-info (device what)
-  (let ((path (make-pathname :directory `(:absolute "sys" "class" "net" ,device "wireless"))))
-    (with-open-file (in (merge-pathnames (make-pathname :name what)
-                                         path))
-      (read-line-from-sysfs in))))
-
-(defun read-wifi-info-int (device what)
-  (parse-integer (read-wifi-info device what)))
-
-
 (defun-cached fmt-wifi 5 (ml)
   "Formatter for wifi status. Displays the ESSID of the access point
 you're connected to as well as the signal strength. When no valid data
@@ -66,18 +56,22 @@ is found, just displays nil."
   (declare (ignore ml))
   (handler-case
       (let* ((device (or *wireless-device* (guess-wireless-device)))
+             (iwconfig (run-shell-command (format nil "~A ~A 2>/dev/null"
+                                                  *iwconfig-path*
+                                                  device)
+                                          t))
              (essid (multiple-value-bind (match? sub)
-                        (cl-ppcre:scan-to-strings "ESSID:\"(.*)\""
-                                                  (run-shell-command (format nil "~A ~A 2>/dev/null"
-                                                                             *iwconfig-path*
-                                                                             device)
-                                                                     t))
+                        (cl-ppcre:scan-to-strings "ESSID:\"(.*)\"" iwconfig)
                       (if match?
                           (aref sub 0)
-                          (return-from fmt-wifi "no link")))))
-        (let* ((qual (read-wifi-info-int device "link")))
-          (format nil "~A ^[~A~D%^]"
-                  essid (bar-zone-color qual 40 30 15 t) qual)))
+                          (return-from fmt-wifi "no link"))))
+             (qual (multiple-value-bind (match? sub)
+                       (cl-ppcre:scan-to-strings "Link Quality=(\\d+)/(\\d+)" iwconfig)
+                     (truncate (float (* (/ (parse-integer (aref sub 0))
+                                            (parse-integer (aref sub 1)))
+                                         100))))))
+        (format nil "~A ^[~A~D%^]"
+                essid (bar-zone-color qual 80 60 40 t) qual))
     ;; CLISP has annoying newlines in their error messages... Just
     ;; print a string showing our confusion.
     (t (c) (format nil "~A" c))))


### PR DESCRIPTION
The sysfs interface this module relied upon is gone, deprecated. We can still guess the wireless device from /sys though, while reading signal strength from iwconfig like we do essid.
