### PR TITLE
Add a restart in case the battery is not found.

### DIFF
--- a/modeline/battery/README.org
+++ b/modeline/battery/README.org
@@ -10,3 +10,6 @@ Then you can use "%b" in your mode line format.
 ** Notes
 This is specific to Linux.
 
+** Possible Improvements
+- [ ] figure out how to signal a recalculation when charger is plugged.
+- [ ] Benchmark the use of Hashtables of alists or plists.

--- a/modeline/battery/battery.asd
+++ b/modeline/battery/battery.asd
@@ -1,11 +1,13 @@
 ;;;; battery.asd
 
 (asdf:defsystem #:battery
-  :serial t
   :description "Describe battery here"
   :author "Vitaly Mayatskikh"
+  :maintainer "Julian Stecklina"
   :license "GPLv3"
-  :depends-on (#:stumpwm)
-  :components ((:file "package")
-               (:file "battery")))
+  :version "0.2.0"
+  :depends-on (#:stumpwm
+               #:cl-ppcre
+               #:uiop)
+  :components ((:file "battery")))
 

--- a/modeline/battery/package.lisp
+++ b/modeline/battery/package.lisp
@@ -1,5 +1,0 @@
-;;;; package.lisp
-
-(defpackage #:battery
-  (:use #:cl :stumpwm))
-


### PR DESCRIPTION
The idea is to handle errors more gracefully. in this case although it works on emacs (screenshoot attached), for the restart to be invoked in stumpwm we would have to modify `#'stumpwm-interal-loop` to recognize stumpwm conditions. I'm still trying to figure out how restart system works and how can `*query-io*` interact with the command system, which seems the natural fit for prompting the user for input. We could borrow more heavily from [CLIM command processing](http://www.lispworks.com/documentation/lw51/CLIM/html/climuser-193.htm#pgfId-407790) that StumpWM seems inspired on. 

This is depends on the PR https://github.com/stumpwm/stumpwm/pull/211 as it requires the stumpwm-error to be exported from the stumpwm package

I also cleaned up the style a little bit and addeda few suggestions for further improvement.

![image](https://cloud.githubusercontent.com/assets/387111/8511087/910acb3a-22cd-11e5-892a-8abc707a5f2a.png)