### PR TITLE
Adds winner-mode module.

### DIFF
--- a/util/winner-mode/README.org
+++ b/util/winner-mode/README.org
@@ -1,0 +1,55 @@
+* winner-mode
+
+** Usage
+
+This only works per group.
+
+Put:
+
+#+BEGIN_SRC lisp
+(load-module "winner-mode")
+#+END_SRC
+
+In your =~/.stumpwmrc=, then the =winner-undo= and =winner-redo=
+commands will be available. I recommend binding these keys like this:
+
+#+BEGIN_SRC lisp
+(defvar *winner-map* (make-sparse-keymap))
+
+(define-key *root-map* (kbd "c") '*winner-map*)
+
+(define-key *winner-map* (kbd "Left") "winner-undo")
+(define-key *winner-map* (kbd "Right") "winner-redo")
+#+END_SRC
+
+=winner-mode= works by dumping layouts and restoring them. It means it
+needs to hook into stumpwm to dump layouts.
+
+You *have* to add the hooks yourself.
+
+Here are the minimum hooks you want to add:
+
+#+BEGIN_SRC lisp
+(add-hook *new-frame-hook* #'winner-mode:dump-group-to-file)
+(add-hook *new-window-hook* #'winner-mode:dump-group-to-file)
+(add-hook *destroy-window-hook* #'winner-mode:dump-group-to-file)
+(add-hook *place-window-hook* #'winner-mode:dump-group-to-file)
+#+END_SRC
+
+** Example
+
+- Be with 4 frames
+- Hit =C-t Q= (aka =only=) to have a single one
+- Hit =C-t c <left-arrow>= to go back to the 4-frames setup
+- Hit =C-t c <right-arrow>= to go back to the 1-frame setup
+
+** API
+
+By default, =winner-mode= stores dumps of layouts in =/tmp/=. If you
+want to change this folder, you can override
+=winner-mode:*tmp-folder*=, e.g.:
+
+#+BEGIN_SRC lisp
+(load-module "winner-mode")
+(setf winner-mode:*tmp-folder* (merge-pathnames #p"tmp/" (user-homedir-pathname)))
+#+END_SRC

--- a/util/winner-mode/README.org
+++ b/util/winner-mode/README.org
@@ -27,13 +27,14 @@ needs to hook into stumpwm to dump layouts.
 
 You *have* to add the hooks yourself.
 
-Here are the minimum hooks you want to add:
+For convenience, =winner-mode= provides a list of commands in
+=winner-mode:*default-commands*=, so you can just add this hook to
+start off:
 
 #+BEGIN_SRC lisp
-(add-hook *new-frame-hook* #'winner-mode:dump-group-to-file)
-(add-hook *new-window-hook* #'winner-mode:dump-group-to-file)
-(add-hook *destroy-window-hook* #'winner-mode:dump-group-to-file)
-(add-hook *place-window-hook* #'winner-mode:dump-group-to-file)
+(add-hook *post-command-hook* (lambda (command)
+                                (when (member command winner-mode:*default-commands*)
+                                  (winner-mode:dump-group-to-file))))
 #+END_SRC
 
 ** Example

--- a/util/winner-mode/dumper.lisp
+++ b/util/winner-mode/dumper.lisp
@@ -1,0 +1,20 @@
+(in-package #:winner-mode)
+
+(defun current-group-number ()
+  (slot-value (stumpwm:current-group) 'number))
+
+(defun dump-name (group-number id)
+  (merge-pathnames
+   (pathname (format nil "stumpwm-winner-mode-~d-~10,'0d" group-number id))
+   *tmp-folder*))
+
+(defun dump-group-to-file (&rest args)
+  (declare (ignore args))
+  (let* ((group-number (current-group-number)))
+    (check-ids group-number *current-ids* *max-ids*)
+    (stumpwm:dump-group-to-file
+     (dump-name group-number (incf (gethash group-number *current-ids*))))
+    (when (> (gethash group-number *current-ids*)
+             (gethash group-number *max-ids*))
+      (setf (gethash group-number *max-ids*)
+            (gethash group-number *current-ids*)))))

--- a/util/winner-mode/macros.lisp
+++ b/util/winner-mode/macros.lisp
@@ -1,0 +1,7 @@
+(in-package #:winner-mode)
+
+(defmacro check-ids (group-number &body ids)
+  `(progn
+     ,@(loop for id in ids
+          collect `(unless (gethash ,group-number ,id)
+                     (setf (gethash ,group-number ,id) 0)))))

--- a/util/winner-mode/package.lisp
+++ b/util/winner-mode/package.lisp
@@ -1,3 +1,3 @@
 (defpackage #:winner-mode
   (:use :cl)
-  (:export :winner-undo :winner-redo :*tmp-folder* :dump-group-to-file))
+  (:export :winner-undo :winner-redo :*tmp-folder* :dump-group-to-file :*default-commands*))

--- a/util/winner-mode/package.lisp
+++ b/util/winner-mode/package.lisp
@@ -1,0 +1,3 @@
+(defpackage #:winner-mode
+  (:use :cl)
+  (:export :winner-undo :winner-redo :*tmp-folder* :dump-group-to-file))

--- a/util/winner-mode/variables.lisp
+++ b/util/winner-mode/variables.lisp
@@ -1,0 +1,5 @@
+(in-package #:winner-mode)
+
+(defvar *current-ids* (make-hash-table))
+(defvar *max-ids* (make-hash-table))
+(defvar *tmp-folder* #p"/tmp/")

--- a/util/winner-mode/variables.lisp
+++ b/util/winner-mode/variables.lisp
@@ -3,3 +3,32 @@
 (defvar *current-ids* (make-hash-table))
 (defvar *max-ids* (make-hash-table))
 (defvar *tmp-folder* #p"/tmp/")
+(defvar *default-commands*
+  '(stumpwm:only
+    stumpwm:pull-from-windowlist
+    stumpwm:pull-hidden-next
+    stumpwm:pull-hidden-other
+    stumpwm:pull-hidden-previous
+    stumpwm:pull-marked
+    stumpwm:pull-window-by-number
+    stumpwm:next
+    stumpwm:next-in-frame
+    stumpwm:next-urgent
+    stumpwm:prev
+    stumpwm:prev-in-frame
+    stumpwm:select-window
+    stumpwm:select-from-menu
+    stumpwm:select-window-by-name
+    stumpwm:select-window-by-number
+    stumpwm::pull
+    stumpwm::remove
+    stumpwm:iresize
+    stumpwm:vsplit
+    stumpwm:hsplit
+    stumpwm:move-window
+    stumpwm:move-windows-to-group
+    stumpwm:move-window-to-group
+    stumpwm:balance-frames
+    stumpwm::delete
+    stumpwm::kill
+    stumpwm:fullscreen))

--- a/util/winner-mode/winner-mode.asd
+++ b/util/winner-mode/winner-mode.asd
@@ -1,0 +1,11 @@
+(asdf:defsystem #:winner-mode
+  :serial t
+  :description "Emacs' winner-mode for StumpWM"
+  :author "Florian Margaine <florian@margaine.com>"
+  :license "GPLv3"
+  :depends-on (:stumpwm)
+  :components ((:file "package")
+               (:file "macros")
+               (:file "variables")
+               (:file "dumper")
+               (:file "winner-mode")))

--- a/util/winner-mode/winner-mode.lisp
+++ b/util/winner-mode/winner-mode.lisp
@@ -1,0 +1,23 @@
+(in-package #:winner-mode)
+
+(stumpwm:defcommand winner-undo () ()
+  "Go back to the last frame setup"
+  (let* ((group-number (current-group-number)))
+    (check-ids group-number *current-ids*)
+    (if (> (gethash group-number *current-ids*) 1)
+        (stumpwm:restore-from-file
+         (dump-name
+          group-number
+          (decf (gethash group-number *current-ids*))))
+        (error "No previous frame setup"))))
+
+(stumpwm:defcommand winner-redo () ()
+  "Go forward to the next frame setup"
+  (let* ((group-number (current-group-number)))
+    (check-ids group-number *current-ids* *max-ids*)
+    (if (= (gethash group-number *max-ids*) (gethash group-number *current-ids*))
+        (error "No next frame setup")
+        (stumpwm:restore-from-file
+         (dump-name
+          group-number
+          (incf (gethash group-number *current-ids*)))))))


### PR DESCRIPTION
winner-mode lets you have a similar workflow as in emacs, using its
winner-mode. Whenever possible, the layout is dumped to a file, and a
few commands let you cycle through the dumped layouts.

This module would love https://github.com/stumpwm/stumpwm/pull/230 to be merged, and the README.org could be updated to have the new hooks in it.