### PR TITLE
Clean up the dumps before leaving.

### DIFF
--- a/util/winner-mode/winner-mode.lisp
+++ b/util/winner-mode/winner-mode.lisp
@@ -21,3 +21,9 @@
          (dump-name
           group-number
           (incf (gethash group-number *current-ids*)))))))
+
+(stumpwm:add-hook stumpwm:*quit-hook* (lambda ()
+                                        (mapcar #'delete-file
+                                                (directory (merge-pathnames
+                                                            #p"stumpwm-winner-mode-*"
+                                                            *tmp-folder*)))))


### PR DESCRIPTION
In itself, it's not a big issue, but leftover files could be left in /tmp/ or w/e temporary folder is used.