### PR TITLE
Fix command screenshot in module screenshot

### DIFF
--- a/util/screenshot/screenshot.lisp
+++ b/util/screenshot/screenshot.lisp
@@ -41,7 +41,7 @@
     (filename)
   ((:rest "Filename: "))
   "Make screenshot of root window"
-  (%screenshot-window (stumpwm:screen-root (stumpwm:current-screen)) filename))
+  (%screenshot-window (xlib:screen-root (stumpwm:screen-number (stumpwm:current-screen))) filename))
 
 (stumpwm:defcommand screenshot-window
     (filename)


### PR DESCRIPTION
I installed stumpwm 0.9.9 and its contrib modules and test the screenshot module. I got an error indicating that stumpwm does not export the srceen-root function. Hacking a little bit I manage to get it working but surely the fix it is not the best one.

Thanks.