### PR TITLE
Add stumptray mode line placeholder

### DIFF
--- a/util/stumptray/package.lisp
+++ b/util/stumptray/package.lisp
@@ -4,6 +4,7 @@
   (:use #:cl #:alexandria)
   (:export *tray-viwin-background*
            *tray-hiwin-background*
+           *tray-placeholder-pixels-per-space*
 
            add-mode-line-hooks
            remove-mode-line-hooks

--- a/util/stumptray/stumptray.lisp
+++ b/util/stumptray/stumptray.lisp
@@ -673,6 +673,22 @@ passed to `xlib:process-event'."
   (stumpwm:remove-hook stumpwm:*destroy-mode-line-hook* #'destroy-mode-line-hook)
   nil)
 
+;;; Mode line placeholder
+
+(defparameter *tray-placeholder-pixels-per-space* 9)
+
+(defun mode-line-tray-placeholder (ml)
+  (let ((tray (screen-tray (stumpwm::mode-line-screen ml))))
+    (if (and tray (eq ml (tray-mode-line tray)))
+        (make-string (floor (tray-width tray)
+                            *tray-placeholder-pixels-per-space*)
+                     :initial-element #\Space)
+        "")))
+
+(stumpwm:add-screen-mode-line-formatter #\T 'mode-line-tray-placeholder)
+
+;;; Commands
+
 (stumpwm:defcommand stumptray () ()
   "Enable tray for current screen"
   (if (current-tray)


### PR DESCRIPTION
This is a rather crude "solution" for #25. I'm not sure if we should merge something like this, but it's a workaround that does work.

With this, one can add `%T` to the mode line at the place the tray would be displayed. This is normally the right side, but that's configurable. If you don't use the default font, you also need to set `stumptray:*tray-placeholder-pixels-per-space*` to a number appropriate for the font used at the place of the placeholder.

Fixes #25
