### PR TITLE
Export *DISK-MODELINE-FMT*

### DIFF
--- a/modeline/disk/disk.lisp
+++ b/modeline/disk/disk.lisp
@@ -43,7 +43,8 @@
              while i
              collect (disk-usage-tokenize i)))))
 
-(defvar *disk-usage-paths* '("/"))
+(defvar *disk-usage-paths* '("/")
+  "The list of mount points to report the disk usage of.")
 
 
 (defun disk-usage-get-field (path field-number)

--- a/modeline/disk/package.lisp
+++ b/modeline/disk/package.lisp
@@ -1,5 +1,7 @@
 ;;;; package.lisp
 
 (defpackage #:disk
-  (:use #:cl :stumpwm))
+  (:use #:cl :stumpwm)
+  (:export
+   #:*disk-modeline-fmt*))
 

--- a/modeline/disk/package.lisp
+++ b/modeline/disk/package.lisp
@@ -3,5 +3,6 @@
 (defpackage #:disk
   (:use #:cl :stumpwm)
   (:export
-   #:*disk-modeline-fmt*))
+   #:*disk-modeline-fmt*
+   #:*disk-usage-paths*))
 


### PR DESCRIPTION
It is intended to be be modified by the user to customize the output of
the disk usage information so it should be exported.