### PR TITLE
Return from a explicit block that the return-from needs.

### DIFF
--- a/modeline/wifi/wifi.asd
+++ b/modeline/wifi/wifi.asd
@@ -5,7 +5,7 @@
   :description "Describe wifi here"
   :author "John Li"
   :license "GPLv3"
-  :depends-on (#:stumpwm)
+  :depends-on (#:stumpwm
+               #:alexandria)
   :components ((:file "package")
                (:file "wifi")))
-


### PR DESCRIPTION
When disconnecting from a WiFi network, the "%I" on the modeline was
blinking from the last WiFi ESSID to NIL and back, until StumpWM got
restarted.

This change sets "no link" by default and also creates a surrounding
block lexical scope for the return-from to correctly work.