### PR TITLE
Fix temperature format

### DIFF
--- a/modeline/cpu/cpu.lisp
+++ b/modeline/cpu/cpu.lisp
@@ -128,4 +128,4 @@ utilization."
                       (get-proc-file-field (cdr *acpi-thermal-zone*) "temperature")
                       :junk-allowed t))
             (:sysfs   (with-open-file (f (cdr *acpi-thermal-zone*))
-                        (/ (read f) 1000))))))
+                        (/ (read f) 1000.0))))))


### PR DESCRIPTION
In mode line, the temperature is displayed as "139/5" instead of "27.8". Changing denominator to float fix it.