### PR TITLE
Show mute state in amixer notification

### DIFF
--- a/media/amixer/amixer.lisp
+++ b/media/amixer/amixer.lisp
@@ -12,11 +12,15 @@
 
 (defun volcontrol (device channel amount)
   (let* ((output (run-shell-command
-                  (concat "amixer -D " (or device "default") " sset " channel " " (or amount "toggle")
-                          "| tail -1")
+                  (concat "amixer -D "
+                          (or device "default")
+                          " sset "
+                          channel
+                          " "
+                          (or amount "toggle"))
                   t))
          (percent-status (nth-value 1
-                                    (cl-ppcre:scan-to-strings ".*\\[([0-9]+)%\\].*\\[(on|off)\\]"
+                                    (cl-ppcre:scan-to-strings "^.*\\[([0-9]+)%\\].*\\[(on|off)\\]\\n"
                                                               output)))
          (percent (if (string= (aref percent-status 1) "off")
                       0

--- a/media/amixer/amixer.lisp
+++ b/media/amixer/amixer.lisp
@@ -11,12 +11,16 @@
 ;;; Code:
 
 (defun volcontrol (device channel amount)
-  (let ((percent (parse-integer
-                  (run-shell-command
-                   (concat "amixer -D " (or device "default") " sset " channel " " (or amount "toggle")
-                           "| tail -1"
-                           "| sed 's/^.*\\[\\([[:digit:]]\\+\\)%\\].*$/\\1/'")
-                   t))))
+  (let* ((output (run-shell-command
+                  (concat "amixer -D " (or device "default") " sset " channel " " (or amount "toggle")
+                          "| tail -1")
+                  t))
+         (percent-status (nth-value 1
+                                    (cl-ppcre:scan-to-strings ".*\\[([0-9]+)%\\].*\\[(on|off)\\]"
+                                                              output)))
+         (percent (if (string= (aref percent-status 1) "off")
+                      0
+                      (parse-integer (aref percent-status 0)))))
     (message
      (concat "Mixer: " channel " " (or amount "toggled")
              (format nil "~C^B~A%" #\Newline percent) "^b [^[^7*"


### PR DESCRIPTION
This is done by simply showing an empty bar. This would solve #67.