### PR TITLE
Remove ^ from regex - .* doesn't include newlines

### DIFF
--- a/media/amixer/amixer.lisp
+++ b/media/amixer/amixer.lisp
@@ -20,7 +20,7 @@
                           (or amount "toggle"))
                   t))
          (percent-status (nth-value 1
-                                    (cl-ppcre:scan-to-strings "^.*\\[([0-9]+)%\\].*\\[(on|off)\\]\\n"
+                                    (cl-ppcre:scan-to-strings ".*\\[([0-9]+)%\\].*\\[(on|off)\\]\\n"
                                                               output)))
          (percent (if (string= (aref percent-status 1) "off")
                       0


### PR DESCRIPTION
amixer's output is (or can be) multiline. This breaks the regex, because
.* doesn't match newlines by default. Removing ^ should be a safe edit
because we aren't using anything from .* before the first [ anyway, with
or without the newlines. 

my system if it matters:

amixer version 1.1.4 (pulseaudio)
SBCL 1.3.16-2.1-suse
stumpwm "1.0.0-111-gb740b04 Compiled On Fri May 26 2017 12:56:04"

amixer's multiline output:

Simple mixer control 'Master',0
  Capabilities: pvolume pswitch pswitch-joined
  Playback channels: Front Left - Front Right
  Limits: Playback 0 - 65536
  Mono:
  Front Left: Playback 15709 [24%] [on]
  Front Right: Playback 15709 [24%] [on]