### PR TITLE
Add a pinentry module.

### DIFF
--- a/README.org
+++ b/README.org
@@ -78,3 +78,4 @@ to the world!
 - [[./util/undocumented/README.org][undocumented]]
 - [[./util/windowtags/README.org][windowtags]]
 - [[./util/kbd-layouts/README.org][kbd-layouts]]
+- [[./util/pinentry/README.org][pinentry]]

--- a/util/pinentry/README.org
+++ b/util/pinentry/README.org
@@ -1,0 +1,15 @@
+** Usage
+
+Put the following in your =~/.stumpwmrc=:
+
+#+BEGIN_SRC lisp
+(load-module "pinentry")
+#+END_SRC
+
+And set the following in your =~/.gnupg/gpg-agent.conf=:
+
+#+BEGIN_SRC
+pinentry-program /absolute/path/to/stumpwm-contrib/util/pinentry/stumpwm-pinentry
+#+END_SRC
+
+GnuPG Agent will now use StumpWM to ask for your password.

--- a/util/pinentry/pinentry.asd
+++ b/util/pinentry/pinentry.asd
@@ -1,0 +1,7 @@
+(asdf:defsystem #:pinentry
+  :serial t
+  :description "Integrate GnuPG Agent with StumpWM"
+  :author "Florian Margaine <florian@margaine.com>"
+  :license "GPLv3"
+  :depends-on (:bordeaux-threads :cffi :stumpwm :usocket-server)
+  :components ((:file "pinentry")))

--- a/util/pinentry/pinentry.lisp
+++ b/util/pinentry/pinentry.lisp
@@ -1,0 +1,14 @@
+(defpackage #:pinentry
+  (:use #:cl))
+
+(in-package #:pinentry)
+
+(defun main (stream)
+  (let ((password (stumpwm:read-one-line (stumpwm:current-screen)
+                                         "Passphrase: "
+                                         :password t)))
+    (format stream password)))
+
+(usocket:socket-server "127.0.0.1" 22222 #'main nil
+                       :in-new-thread t
+                       :multi-threading t)

--- a/util/pinentry/stumpwm-pinentry
+++ b/util/pinentry/stumpwm-pinentry
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+echo OK Your orders please
+
+while IFS="\n" read -r command; do
+    if [ "$command" == "GETINFO flavor" ]; then
+        echo D stumpwm
+    elif [ "$command" == "GETINFO pid" ]; then
+        echo D $PID
+    elif [ "$command" == GETPIN ]; then
+        password=$(echo -n "" | nc 127.0.0.1 22222)
+        echo D "$password"
+    elif [ "$command" == BYE ]; then
+        exit 0
+    fi
+
+    echo OK
+done < /dev/stdin


### PR DESCRIPTION
This module lets you completely integrate GnuPG Agent with
StumpWM. After correctly configuring it, whenever gpg-agent will need
a passphrase for a GPG key (or an SSH key, if you have enabled SSH
support), a StumpWM prompt will ask for the password.