### PR TITLE
Allow reloading xmodmap on each layout change

### DIFF
--- a/util/kbd-layouts/kbd-layouts.lisp
+++ b/util/kbd-layouts/kbd-layouts.lisp
@@ -17,6 +17,9 @@
 ;; Custom option string appended to setxkbmap
 (defvar *custom-setxkb-options* nil)
 
+;; Run xmodmap ~/.Xmodmap each time layouts are switched
+(defvar *run-xmodmap* t)
+
 ;;;;;;;;;;;;;;;;;;;;;;
 ;; Helper functions ;;
 ;;;;;;;;;;;;;;;;;;;;;;
@@ -51,7 +54,9 @@
                  (:ctrl "ctrl:nocaps")
                  (:swapped "ctrl:swapcaps")))
          (cmd (format nil "setxkbmap ~a -option ~a~@[ ~a~]" layout caps *custom-setxkb-options*)))
-    (run-shell-command cmd t)
+    (run-shell-command cmd nil)
+    (when *run-xmodmap*
+      (run-shell-command "xmodmap ~/.Xmodmap"))
     (message (format nil "Keyboard layout switched to: ~a" layout))))
 
 ;;;;;;;;;;;;;;

--- a/util/kbd-layouts/package.lisp
+++ b/util/kbd-layouts/package.lisp
@@ -4,6 +4,7 @@
   (:use #:cl #:stumpwm)
   (:export *caps-lock-behavior*
            *custom-setxkb-options*
+           *run-xmodmap*
            keyboard-layout-list))
 
 


### PR DESCRIPTION
Hi,
I've updated my module `xkb-layoutx` to allow automatic reload of xmodmap. It's helpful when you have some non-standard key mappings and want to preserve them over layout switches.