### PR TITLE
Save *input-history* on quitting StumpWM and reloading it again on start

### DIFF
--- a/README.org
+++ b/README.org
@@ -78,3 +78,4 @@ to the world!
 - [[./util/windowtags/README.org][windowtags]]
 - [[./util/kbd-layouts/README.org][kbd-layouts]]
 - [[./util/pinentry/README.org][pinentry]]
+- [[./util/command-history/README.org][command-history]]

--- a/util/command-history/README.md
+++ b/util/command-history/README.md
@@ -2,7 +2,7 @@
 
 ** Problem
 After quiting StumpWM, you command history is gone.
-This simple plugin saves the *stumpwm::*input-history* to ~/.stumpwm.d/history and loads it again when starting StumpWM.
+This simple plugin saves the \*stumpwm::\*input-history\* to ~/.stumpwm.d/history and loads it again when starting StumpWM.
 
 ** Usage
 Add this to your =.stumpwmrc=:

--- a/util/command-history/README.md
+++ b/util/command-history/README.md
@@ -1,6 +1,6 @@
 # command-history
 
-*** Problem
+** Problem
 After quiting StumpWM, you command history is gone.
 This simple plugin saves the *stumpwm::*input-history* to ~/.stumpwm.d/history and loads it again when starting StumpWM.
 

--- a/util/command-history/README.md
+++ b/util/command-history/README.md
@@ -1,10 +1,13 @@
 # command-history
 
-** Problem
+## Problem
 After quiting StumpWM, you command history is gone.
-This simple plugin saves the \*stumpwm::\*input-history\* to ~/.stumpwm.d/history and loads it again when starting StumpWM.
+This simple plugin saves the
+#+BEGIN_SRC lisp
+*stumpwm::*input-history* to ~/.stumpwm.d/history and loads it again when starting StumpWM.
+#+END_SRC
 
-** Usage
+## Usage
 Add this to your =.stumpwmrc=:
 
 Load contrib module:

--- a/util/command-history/README.md
+++ b/util/command-history/README.md
@@ -1,6 +1,6 @@
 # command-history
 
-***** Problem
+*** Problem
 After quiting StumpWM, you command history is gone.
 This simple plugin saves the *stumpwm::*input-history* to ~/.stumpwm.d/history and loads it again when starting StumpWM.
 
@@ -11,7 +11,3 @@ Load contrib module:
 #+BEGIN_SRC lisp
   (load-module "command-history")
 #+END_SRC
-
-Moreover there is a couple of util functions exported for the aim of
-user-defined extensions - see source code.
-

--- a/util/command-history/README.md
+++ b/util/command-history/README.md
@@ -1,0 +1,9 @@
+# command-history
+### _Your Name <your.name@example.com>_
+
+This is a project to do ... something.
+
+## License
+
+Specify license here
+

--- a/util/command-history/README.md
+++ b/util/command-history/README.md
@@ -1,9 +1,17 @@
 # command-history
-### _Your Name <your.name@example.com>_
 
-This is a project to do ... something.
+***** Problem
+After quiting StumpWM, you command history is gone.
+This simple plugin saves the *stumpwm::*input-history* to ~/.stumpwm.d/history and loads it again when starting StumpWM.
 
-## License
+** Usage
+Add this to your =.stumpwmrc=:
 
-Specify license here
+Load contrib module:
+#+BEGIN_SRC lisp
+  (load-module "command-history")
+#+END_SRC
+
+Moreover there is a couple of util functions exported for the aim of
+user-defined extensions - see source code.
 

--- a/util/command-history/README.org
+++ b/util/command-history/README.org
@@ -2,7 +2,7 @@
 
 *** Problem
 After quiting StumpWM, you command history is gone.
-This simple plugin saves the lisp =*stumpwm::*input-history*= to =~/.stumpwm.d/history= and loads it again when starting StumpWM.
+This simple plugin saves the lisp =stumpwm::*input-history*= to =~/.stumpwm.d/history= and loads it again when starting StumpWM.
 
 ** Usage
 Add this to your =.stumpwmrc=:

--- a/util/command-history/README.org
+++ b/util/command-history/README.org
@@ -1,13 +1,10 @@
 # command-history
 
-## Problem
+*** Problem
 After quiting StumpWM, you command history is gone.
-This simple plugin saves the
-#+BEGIN_SRC lisp
-*stumpwm::*input-history* to ~/.stumpwm.d/history and loads it again when starting StumpWM.
-#+END_SRC
+This simple plugin saves the lisp =*stumpwm::*input-history*= to =~/.stumpwm.d/history= and loads it again when starting StumpWM.
 
-## Usage
+** Usage
 Add this to your =.stumpwmrc=:
 
 Load contrib module:

--- a/util/command-history/command-history.asd
+++ b/util/command-history/command-history.asd
@@ -1,0 +1,11 @@
+;;;; command-history.asd
+
+(asdf:defsystem #:command-history
+  :description "Save and load the stumpwm::*input-history* to a file"
+  :author "Arjen Dijkstra"
+  :license "GPLv3"
+  :version "0.0.1"
+  :serial t
+  :depends-on (#:stumpwm)
+  :components ((:file "package")
+               (:file "command-history")))

--- a/util/command-history/command-history.lisp
+++ b/util/command-history/command-history.lisp
@@ -2,6 +2,8 @@
 
 (in-package #:command-history)
 
+(export '(*start-hook*
+          *quit-hook*))
 
 (defvar *home-dir* (getenv "HOME"))
 

--- a/util/command-history/command-history.lisp
+++ b/util/command-history/command-history.lisp
@@ -1,0 +1,32 @@
+;;;; command-history.lisp
+
+(in-package #:command-history)
+
+
+(defvar *home-dir* (getenv "HOME"))
+
+(defvar *command-history-file*
+  (merge-pathnames
+    (format nil "~A/.stumpwm.d/history" *home-dir*)))
+
+(defun load-input-history ()
+  "Load *input-history* to file."
+  (with-open-file (in *command-history-file* :if-does-not-exist nil)
+    (when in
+      (with-standard-io-syntax
+        (setf stumpwm::*input-history* (read in))))))
+
+(defun save-input-history ()
+  "Save current *input-history* to file."
+  (with-open-file (out *command-history-file*
+                       :direction :output
+                       :if-does-not-exist :create
+                       :if-exists :supersede)
+    (with-standard-io-syntax
+      (print
+        (remove-duplicates stumpwm::*input-history* :test #'string= :from-end t)
+        out))))
+
+(add-hook *start-hook* 'load-input-history)
+
+(add-hook *quit-hook* 'save-input-history)

--- a/util/command-history/package.lisp
+++ b/util/command-history/package.lisp
@@ -1,6 +1,4 @@
 ;;;; package.lisp
 
 (defpackage #:command-history
-  (:use #:cl :stumpwm)
-  (export '(*start-hook*
-            *quit-hook*)))
+  (:use #:cl :stumpwm))

--- a/util/command-history/package.lisp
+++ b/util/command-history/package.lisp
@@ -1,0 +1,6 @@
+;;;; package.lisp
+
+(defpackage #:command-history
+  (:use #:cl :stumpwm)
+  (export '(*start-hook*
+            *quit-hook*)))


### PR DESCRIPTION
I'd like to save the *input-history* on quitting StumpWM and reloading it again on start, so I can navigate to older commands.