### PR TITLE
Misc changes to the NOTIFY contrib

### DIFF
--- a/util/notify/README.org
+++ b/util/notify/README.org
@@ -6,14 +6,15 @@ Shows notifications using =stumpwm:message= by default.
 ** Usage
 Add
 #+begin_src lisp
-(load-module "notify")
+  (load-module "notify")
+  (notify:notify-server-toggle)
 #+end_src
 to =.stumpwmrc=
 
 Now you can run default server using =notify-server-toggle=.
 In order to get your own notifications handler you can define on function
 #+begin_src lisp
-(defun notification-handler (app icon summary body)
-  "Does things with incoming notifications"
-  . . .)
+  (defun notification-handler (app icon summary body)
+    "Does things with incoming notifications"
+    ...)
 #+end_src

--- a/util/notify/notify.asd
+++ b/util/notify/notify.asd
@@ -1,13 +1,11 @@
-;;;; notify.asd
-
-(asdf:defsystem :notify
+(asdf:defsystem "notify"
     :serial t
     :description "DBus-based notification server part"
     :author "Slava Barinov <rayslava@gmail.com>"
     :license "GPLv3"
-    :depends-on (#:stumpwm
-		 #:xml-emitter
-		 #:dbus
-		 #:bordeaux-threads)
+    :depends-on ("stumpwm"
+                 "xml-emitter"
+                 "dbus"
+                 "bordeaux-threads")
     :components ((:file "package")
-		 (:file "notify")))
+                 (:file "notify")))

--- a/util/notify/notify.lisp
+++ b/util/notify/notify.lisp
@@ -1,4 +1,3 @@
-;;;; notify.lisp
 (in-package #:notify)
 
 ;;;;
@@ -6,7 +5,7 @@
 ;;;;
 
 (defvar *notification-received-hook* 'show-notification
-  "Hook to execute when notification received")
+  "Function to execute when notification received")
 
 (defvar *notify-server-is-on* nil
   "Does notify-server listen to notifications?")
@@ -15,10 +14,10 @@
   "DBus listening thread")
 
 (defparameter *notify-server-start-message*
-  "Server will now listen for notifications")
+  "Notification Server listening for notifications.")
 
 (defparameter *notify-server-stop-message*
-  "Server will now stop listening for notifications")
+  "Notification Server will now stop listening for notifications.")
 
 (defun show-notification (app icon summary body)
   "Show the notification using standard STUMPWM::MESSAGE function"
@@ -60,10 +59,11 @@
 
 (defun notify-server-on ()
   "Turns on notify server."
-  (setf *notify-server-thread*
-	(make-thread #'notifications-listen :name "listener"))
-  (setf *notify-server-is-on* t)
-  (stumpwm:message *notify-server-start-message*))
+  (unless *notify-server-is-on*
+    (setf *notify-server-thread*
+          (make-thread #'notifications-listen :name "listener"))
+    (setf *notify-server-is-on* t)
+    (stumpwm:message *notify-server-start-message*)))
 
 (defun notify-server-off ()
   "Turns off notify server"
@@ -72,7 +72,7 @@
   (stumpwm:message *notify-server-stop-message*))
 
 (stumpwm:defcommand notify-server-toggle () ()
-		    "Toggles notify server."
-		    (if *notify-server-is-on*
-			(notify-server-off)
-			(notify-server-on)))
+  "Toggles notify server."
+  (if *notify-server-is-on*
+      (notify-server-off)
+      (notify-server-on)))

--- a/util/notify/package.lisp
+++ b/util/notify/package.lisp
@@ -3,4 +3,6 @@
 	#:dbus
 	#:bordeaux-threads)
   (:export #:*notification-received-hook*
-	   #:notify-server-toggle))
+	   #:notify-server-toggle
+           #:notify-server-on
+           #:notify-server-off))


### PR DESCRIPTION
- export NOTIFY-SERVER-ON and NOTIFY-SERVER-OFF.

- NOTIFY-SERVER-ON does nothing if the server is already running.

- ASDF system definition, prefer strings to keywords and uniterned
symbols as per ASDF recommended best practices[0].

[0]: https://gitlab.common-lisp.net/asdf/asdf/blob/master/doc/best_practices.md#designating-a-system