### PR TITLE
end-session (restart-computer): actually restart computer

### DIFF
--- a/util/end-session/end-session.lisp
+++ b/util/end-session/end-session.lisp
@@ -66,7 +66,7 @@ Returns true when yes is selected"
       (echo-string (current-screen) "Restarting...")
       (close-all-apps)
       (run-hook *quit-hook*)
-      (run-shell-command "systemctl restart"))))
+      (run-shell-command "systemctl reboot"))))
 
 (defcommand logout () ()
   (let ((choice (yes-no-diag "Close all programs and quit stumpwm?")))


### PR DESCRIPTION
At the moment the `restart-computer` function doesn't actually restart the computer, because it uses the wrong command.

This pull request just changes the command used from `systemctl restart` to `systemctl reboot`.