### PR TITLE
Ensure PASSWD contrib loads

### DIFF
--- a/util/passwd/package.lisp
+++ b/util/passwd/package.lisp
@@ -1,5 +1,6 @@
 ;;;; package.lisp
 
 (defpackage #:passwd
-  (:use #:cl :stumpwm-user ))
+  (:use #:cl
+        #:stumpwm)
 

--- a/util/passwd/passwd.asd
+++ b/util/passwd/passwd.asd
@@ -1,11 +1,12 @@
 ;;;; passwd.asd
 
-(asdf:defsystem #:passwd
+(asdf:defsystem "passwd"
   :serial t
   :description "A simple password utility based on ironclad."
   :author "Anonymous"
   :license "GPLv3"
-  :depends-on (#:stumpwm #:ironclad)
+  :depends-on ("stumpwm"
+               "ironclad")
   :components ((:file "package")
                (:file "passwd")))
 


### PR DESCRIPTION
The package definition should USE the package STUMPWM not
STUMPWM-USER. STUMPWM-USER is designed to run exploratory code that uses
symbols from the STUMPWM package, the package itself exports no symbols.

This PR partially addresses #106. The code itself code remove the sbcl feature expressions and the documentation is still missing. 