### PR TITLE
Update to cpu, net and mem modeline modules

### DIFF
--- a/modeline/cpu/cpu.lisp
+++ b/modeline/cpu/cpu.lisp
@@ -132,10 +132,10 @@ utilization."
                  *cpu-modeline-fmt*))
 
 (defvar *cpu-formatters-alist*
-  '((#\c . fmt-cpu-usage)
-    (#\C . fmt-cpu-usage-bar)
-    (#\f . fmt-cpu-freq)
-    (#\t . fmt-cpu-temp)))
+  '((#\c  fmt-cpu-usage)
+    (#\C  fmt-cpu-usage-bar)
+    (#\f  fmt-cpu-freq)
+    (#\t  fmt-cpu-temp)))
 
 (defvar *cpu-modeline-fmt* "%c (%f) %t"
   "The default value for displaying cpu information on the modeline.

--- a/modeline/cpu/cpu.lisp
+++ b/modeline/cpu/cpu.lisp
@@ -132,10 +132,10 @@ utilization."
                  *cpu-modeline-fmt*))
 
 (defvar *cpu-formatters-alist*
-  '((#\c fmt-cpu-usage)
-    (#\C fmt-cpu-usage-bar)
-    (#\f fmt-cpu-freq)
-    (#\t fmt-cpu-temp)))
+  '((#\c . fmt-cpu-usage)
+    (#\C . fmt-cpu-usage-bar)
+    (#\f . fmt-cpu-freq)
+    (#\t . fmt-cpu-temp)))
 
 (defvar *cpu-modeline-fmt* "%c (%f) %t"
   "The default value for displaying cpu information on the modeline.

--- a/modeline/disk/disk.lisp
+++ b/modeline/disk/disk.lisp
@@ -75,12 +75,12 @@
     (format nil "~{~a ~}" fmts)))
 
 (defvar *disk-formatters-alist*
-  '((#\d disk-get-device)
-    (#\s disk-get-size)
-    (#\u disk-get-used)
-    (#\a disk-get-available)
-    (#\p disk-get-use-percent)
-    (#\m disk-get-mount-point)))
+  '((#\d  disk-get-device)
+    (#\s  disk-get-size)
+    (#\u  disk-get-used)
+    (#\a  disk-get-available)
+    (#\p  disk-get-use-percent)
+    (#\m  disk-get-mount-point)))
 
 (defvar *disk-modeline-fmt* "%m: %u/%s"
   "The default value for displaying disk usage information on the modeline.

--- a/modeline/maildir/maildir.lisp
+++ b/modeline/maildir/maildir.lisp
@@ -93,9 +93,9 @@
 
 
 (defvar *maildir-formatters-alist*
-  '((#\n maildir-get-new)
-    (#\c maildir-get-cur)
-    (#\t maildir-get-tmp)))
+  '((#\n . maildir-get-new)
+    (#\c . maildir-get-cur)
+    (#\t . maildir-get-tmp)))
 
 (defvar *maildir-modeline-fmt* "%n %c"
   "The default value for displaying maildir information on the modeline.

--- a/modeline/mem/mem.lisp
+++ b/modeline/mem/mem.lisp
@@ -48,13 +48,13 @@ total amount of memory, allocated memory, allocated/total ratio"
 
 (defun fmt-mem-percent (mem)
   "Returns a string representing the current percent of used memory."
-  (let* ((|%| (truncate (* 100 (nth 2 mem)))))
-    (format nil "^[~A~3D%^] " (bar-zone-color |%|) |%|)))
+  (let* ((% (truncate (* 100 (nth 2 mem)))))
+    (format nil "^[~A~3D%^] " (bar-zone-color %) %)))
 
 (defun fmt-mem-usage-bar (mem)
   "Returns a coloured bar-graph representing the current allocation of memory."
   (let ((cpu (truncate (* 100 (nth 2 mem)))))
-    (stumpwm::bar cpu *mem-usage-bar-width* *mem-usage-bar-full* *mem-usage-bar-empty*)))
+    (stumpwm:bar cpu *mem-usage-bar-width* *mem-usage-bar-full* *mem-usage-bar-empty*)))
 
 (defun mem-modeline (ml)
   (declare (ignore ml))
@@ -63,9 +63,9 @@ total amount of memory, allocated memory, allocated/total ratio"
                  (mem-usage)))
 
 (defvar *mem-formatters-alist*
-  '((#\a fmt-mem-allocated)
-    (#\p fmt-mem-percent)
-    (#\b fmt-mem-usage-bar)))
+  '((#\a . fmt-mem-allocated)
+    (#\p . fmt-mem-percent)
+    (#\b . fmt-mem-usage-bar)))
 
 (defvar *mem-modeline-fmt* "MEM: %a %p"
   "The default value for displaying mem usage information on the modeline.

--- a/modeline/mem/mem.lisp
+++ b/modeline/mem/mem.lisp
@@ -12,8 +12,7 @@
 ;;;
 
 ;; Install formatters.
-(add-screen-mode-line-formatter #\M 'fmt-mem-usage)
-(add-screen-mode-line-formatter #\N 'fmt-mem-usage-bar)
+(add-screen-mode-line-formatter #\M 'mem-modeline)
 
 ;; Defaults arguments for fmt-mem-usage-bar
 (defvar *mem-usage-bar-width* 10)
@@ -42,16 +41,44 @@ total amount of memory, allocated memory, allocated/total ratio"
       (setq allocated (- mem-total (+ mem-free buffers cached)))
       (list mem-total allocated (/ allocated mem-total)))))
 
-(defun fmt-mem-usage (ml)
-  "Returns a string representing the current percent of used memory."
-  (declare (ignore ml))
-  (let* ((mem (mem-usage))
-	 (|%| (truncate (* 100 (nth 2 mem))))
-	 (allocated (truncate (/ (nth 1 mem) 1000))))
-    (format nil "MEM: ~4D mb ^[~A~3D%^] " allocated (bar-zone-color |%|) |%|)))
+(defun fmt-mem-allocated (mem)
+  "Returns a string representing the current allocated memory."
+  (let* ((allocated (truncate (/ (nth 1 mem) 1000))))
+    (format nil "~4D mb" allocated)))
 
-(defun fmt-mem-usage-bar (ml &optional (width *mem-usage-bar-width*) (full *mem-usage-bar-full*) (empty *mem-usage-bar-empty*))
+(defun fmt-mem-percent (mem)
+  "Returns a string representing the current percent of used memory."
+  (let* ((|%| (truncate (* 100 (nth 2 mem)))))
+    (format nil "^[~A~3D%^] " (bar-zone-color |%|) |%|)))
+
+(defun fmt-mem-usage-bar (mem)
   "Returns a coloured bar-graph representing the current allocation of memory."
+  (let ((cpu (truncate (* 100 (nth 2 mem)))))
+    (stumpwm::bar cpu *mem-usage-bar-width* *mem-usage-bar-full* *mem-usage-bar-empty*)))
+
+(defun mem-modeline (ml)
   (declare (ignore ml))
-  (let ((cpu (truncate (* 100 (nth 2 (mem-usage))))))
-    (stumpwm::bar cpu width full empty)))
+  (format-expand *mem-formatters-alist*
+                 *mem-modeline-fmt*
+                 (mem-usage)))
+
+(defvar *mem-formatters-alist*
+  '((#\a fmt-mem-allocated)
+    (#\p fmt-mem-percent)
+    (#\b fmt-mem-usage-bar)))
+
+(defvar *mem-modeline-fmt* "MEM: %a %p"
+  "The default value for displaying mem usage information on the modeline.
+
+@table @asis
+@item %%
+A literal '%'
+@item %a
+Allocated memory in MB
+@item %p
+Percent of used memory
+@item %b
+Bar graph of current memory allocation
+@end table
+")
+

--- a/modeline/mem/mem.lisp
+++ b/modeline/mem/mem.lisp
@@ -63,9 +63,9 @@ total amount of memory, allocated memory, allocated/total ratio"
                  (mem-usage)))
 
 (defvar *mem-formatters-alist*
-  '((#\a . fmt-mem-allocated)
-    (#\p . fmt-mem-percent)
-    (#\b . fmt-mem-usage-bar)))
+  '((#\a  fmt-mem-allocated)
+    (#\p  fmt-mem-percent)
+    (#\b  fmt-mem-usage-bar)))
 
 (defvar *mem-modeline-fmt* "MEM: %a %p"
   "The default value for displaying mem usage information on the modeline.

--- a/modeline/net/net.lisp
+++ b/modeline/net/net.lisp
@@ -163,10 +163,10 @@ For the second case rescans route table every minute."
                  *net-modeline-fmt*))
 
 (defvar *net-formatters-alist*
-  '((#\d . net-device)
-    (#\u . fmt-net-usage)
-    (#\i . fmt-ipv4)
-    (#\I . fmt-ipv6)))
+  '((#\d  net-device)
+    (#\u  fmt-net-usage)
+    (#\i  fmt-ipv4)
+    (#\I  fmt-ipv6)))
 
 (defvar *net-modeline-fmt* "%d: %u"
   "The default value for displaying net information on the modeline.

--- a/modeline/net/net.lisp
+++ b/modeline/net/net.lisp
@@ -152,14 +152,10 @@ For the second case rescans route table every minute."
 	    (car dn) (cadr dn) (car up) (cadr up))))
 
 (defun fmt-ipv4 ()
-   (if *net-ipv4*
-       *net-ipv4*
-       "noip"))
+  (or *net-ipv4* "noip"))
 
 (defun fmt-ipv6 ()
-  (if *net-ipv6*
-      *net-ipv6*
-      "noip"))
+  (or *net-ipv6* "noip"))
 
 (defun net-modeline (ml)
   (declare (ignore ml))
@@ -167,10 +163,10 @@ For the second case rescans route table every minute."
                  *net-modeline-fmt*))
 
 (defvar *net-formatters-alist*
-  '((#\d net-device)
-    (#\u fmt-net-usage)
-    (#\i fmt-ipv4)
-    (#\I fmt-ipv6)))
+  '((#\d . net-device)
+    (#\u . fmt-net-usage)
+    (#\i . fmt-ipv4)
+    (#\I . fmt-ipv6)))
 
 (defvar *net-modeline-fmt* "%d: %u"
   "The default value for displaying net information on the modeline.

--- a/modeline/net/net.lisp
+++ b/modeline/net/net.lisp
@@ -12,7 +12,7 @@
 ;;;
 
 ;; Install formatters.
-(add-screen-mode-line-formatter #\l 'fmt-net-usage)
+(add-screen-mode-line-formatter #\l 'net-modeline)
 
 (defvar *net-device* nil) ; nil means auto. or specify explicitly, i.e. "wlan0"
 (defvar *net-last-rx* 0)
@@ -124,9 +124,8 @@ For the second case rescans route table every minute."
       (list (round (/ rx-s t-s))
 	    (round (/ tx-s t-s)))))
 
-(defun fmt-net-usage (ml)
+(defun fmt-net-usage ()
   "Returns a string representing the current network activity."
-  (declare (ignore ml))
   (let ((net (net-usage))
 	dn up)
     (defun kbmb (x y)
@@ -135,5 +134,27 @@ For the second case rescans route table every minute."
 	  (list (/ x 1e3) "k")))
     (setq dn (kbmb (car net) 0.1)
 	  up (kbmb (cadr net) 0.1))
-    (format nil "~A: ~5,2F~A/~5,2F~A " (net-device)
+    (format nil "~5,2F~A/~5,2F~A "
 	    (car dn) (cadr dn) (car up) (cadr up))))
+
+(defun net-modeline (ml)
+  (declare (ignore ml))
+  (format-expand *net-formatters-alist*
+                 *net-modeline-fmt*))
+
+(defvar *net-formatters-alist*
+  '((#\d net-device)
+    (#\u fmt-net-usage)))
+
+(defvar *net-modeline-fmt* "%d: %u"
+  "The default value for displaying net information on the modeline.
+
+@table @asis
+@item %%
+A literal '%'
+@item %d
+network device name
+@item %u
+network usage
+@end table
+")


### PR DESCRIPTION
Modified cpu, net and mem modules to export a single modeline formatter.
Each module now comes with its own modeline format string and formatters.
Also added ip address formatter to net module.

Using the single formatter will probably break existing configurations but the default
format string for each module should match the previous behavior.