### PR TITLE
Additional customisation variables to wifi module

### DIFF
--- a/modeline/wifi/README.org
+++ b/modeline/wifi/README.org
@@ -9,6 +9,19 @@ Place the following in your ~/.stumpwmrc file:
 Then you can use "%I" in your mode line format (both "w" and "W"
 were taken. Think _I_EEE 802.11 :-)).
 
+To change the format of the information on the modeline, set
+=wifi:*wifi-modeline-fmt*= (default ="%e %p"=).
+
+| Code | Result                                |
+|------+---------------------------------------|
+| %%   | A literal %                           |
+| %e   | Network ESSID                         |
+| %p   | Signal quality (with percentage sign) |
+| %P   | Signal quality (without percentage)   |
+
+To enable/disable colors in the signal quality indicator, set
+=wifi:*use-colors*= (default =t=).
+
 ** Notes
 This gets information through sysfs, so it only works on Linux with a
 mounted =sysfs=.

--- a/modeline/wifi/package.lisp
+++ b/modeline/wifi/package.lisp
@@ -3,5 +3,7 @@
 (defpackage #:wifi
   (:use #:cl :common-lisp :stumpwm )
   (:export #:*iwconfig-path*
-           #:*wireless-device*))
+           #:*wireless-device*
+           #:*wifi-modeline-fmt*
+           #:*use-colors*))
 

--- a/modeline/wifi/wifi.lisp
+++ b/modeline/wifi/wifi.lisp
@@ -18,6 +18,46 @@
   "Set to the name of the wireless device you want to monitor. If set
   to NIL, try to guess.")
 
+(defvar *wifi-modeline-fmt* "%e %p"
+  "The default value for displaying WiFi information on the modeline.
+
+@table @asis
+@item %%
+A literal '%'
+@item %e
+Network ESSID
+@item %p
+Signal quality (with percentage sign)
+@item %P
+Signal quality (without percentage sign)
+@end table
+")
+
+(defvar *use-colors* nil
+  "Use colors to indicate signal quality.")
+
+(defun sig-quality-fmt (qual)
+  (if *use-colors*
+      (bar-zone-color qual 80 60 40 t)
+      ""))
+
+(defun wifi-get-essid (pair)
+  (let ((essid (car pair)))
+    (format nil "~A" essid)))
+
+(defun wifi-get-signal-quality-pc (pair)
+  (let ((qual (cdr pair)))
+    (format nil "^[~A~D%^]" (sig-quality-fmt qual) qual)))
+
+(defun wifi-get-signal-quality (pair)
+  (let ((qual (cdr pair)))
+    (format nil "^[~A~D^]" (sig-quality-fmt qual) qual)))
+
+(defvar *wifi-formatters-alist*
+  '((#\e wifi-get-essid)
+    (#\p wifi-get-signal-quality-pc)
+    (#\P wifi-get-signal-quality)))
+
 (defmacro defun-cached (name interval arglist &body body)
   "Creates a function that does simple caching. The body must be
 written in a functional style - the value returned is set as the
@@ -69,11 +109,13 @@ is found, just displays nil."
                             (return-from fmt-wifi "no link"))))
                (qual (multiple-value-bind (match? sub)
                          (cl-ppcre:scan-to-strings "Link Quality=(\\d+)/(\\d+)" iwconfig)
+                       (declare (ignorable match?))
                        (truncate (float (* (/ (parse-integer (aref sub 0))
                                               (parse-integer (aref sub 1)))
                                            100))))))
-          (format nil "~A ^[~A~D%^]"
-                  essid (bar-zone-color qual 80 60 40 t) qual))
+          (format-expand *wifi-formatters-alist*
+                         *wifi-modeline-fmt*
+                         (cons essid qual)))
       ;; CLISP has annoying newlines in their error messages... Just
       ;; print a string showing our confusion.
       (t (c) (format nil "~A" c)))))

--- a/modeline/wifi/wifi.lisp
+++ b/modeline/wifi/wifi.lisp
@@ -33,7 +33,7 @@ Signal quality (without percentage sign)
 @end table
 ")
 
-(defvar *use-colors* nil
+(defvar *use-colors* t
   "Use colors to indicate signal quality.")
 
 (defun sig-quality-fmt (qual)


### PR DESCRIPTION
The wifi module had no easy customisation options, so this adds some basic formatting ones internal to the module (implemented similarly to the *disk* module's formatting, so no format character clashes are introduced).

The default configuration is identical to before, so no changes in behaviour should be observable until the format string is changed by the user.

README has been updated to reflect the changes. I've tested it without any breakage.