### PR TITLE
Added support for multiple maildirs

### DIFF
--- a/modeline/maildir/README.org
+++ b/modeline/maildir/README.org
@@ -1,18 +1,26 @@
 ** Usage
+   Put:
+   #+BEGIN_SRC lisp
+     (load-module "maildir")
+   #+END_SRC
+   into your =~/.stumpwmrc=
+   
+   Then you can use =%D= in your mode line format. You can customize the
+   modeline format =*maildir-modeline-fmt*=. The relevant format options
+   are:
+   | Option | Description                               |
+   |--------+-------------------------------------------|
+   | =%l=     | maildir label                             |
+   | =%n=     | number of "new" messages (ie. unread)     |
+   | =%c=     | number of "current" messages (ie. seen)   |
+   | =%t=     | number of "temporary" messages (ie. misc) |
 
-Put:
-#+BEGIN_SRC lisp
-    (load-module "maildir")
-#+END_SRC
-into your =~/.stumpwmrc=
-
-Then you can use "%M" in your mode line format.
-You can customize the modeline format (*maildir-modeline-fmt*). See the
-documentation for *maildir-modeline-fmt* for more information.
-
-** Notes
-
-The %M mode line formatter is also used by the 'mem' module.
-
-** Tasks
-*** TODO Add per mailbox formatter
+   To add a Maildir, add it to the =*maildir-alist*= alist. The car or
+   each item is it's label and the cdr it's pathname. Here's an example
+   of how to add a custom directory.
+   #+BEGIN_SRC lisp
+	 (push (cons "Job" (realname "~/job-mail")) maildir:*maildir-alist*)
+   #+END_SRC
+   
+   By default, only =~/Mail= is indexed. All directories that cannot be
+   found, are ignored.

--- a/modeline/maildir/maildir.lisp
+++ b/modeline/maildir/maildir.lisp
@@ -14,9 +14,8 @@
 ;;; CODE:
 
 (export '(*maildir-alist*
-          *maildir-modeline-fmt*
-
-          maildir-set-update-time))
+		  *maildir-modeline-fmt*
+		  *maildir-update-time*))
 
 
 
@@ -51,15 +50,6 @@ Temporary mails number
 
 
 
-(defun maildir-set-update-time (time-in-seconds)
-  "Set the maildir informations update interval."
-  (when *maildir-timer*
-    (cancel-timer *maildir-timer*))
-  (setf *maildir-update-time* time-in-seconds)
-  (setf *maildir-timer*
-        (run-with-timer *maildir-update-time* *maildir-update-time*
-                        'update-maildir-infos)))
-
 (defun maildir-mailboxes (maildir)
   "Returns a list of all mailboxes in *maildir-path*."
   (directory (merge-pathnames (make-pathname :directory '(:relative :wild))
@@ -68,8 +58,8 @@ Temporary mails number
 (defun maildir-mailbox-dir (mailbox dir-name)
   "Returns the specified sub-directory pathname for the provided mailbox."
   (merge-pathnames (make-pathname :directory (list :relative dir-name)
-                                  :name :wild :type :wild)
-                   mailbox))
+								  :name :wild :type :wild)
+				   mailbox))
 
 (defun update-maildir-infos ()
   "Update mail counts for *maildir-alist*."
@@ -90,10 +80,8 @@ Temporary mails number
   ;; disk access are slow and you obviously don't need to check
   ;; emails every time the modeline gets updated
   (unless *maildir-timer*
-    (update-maildir-infos)
-    (setf *maildir-timer*
-          (run-with-timer *maildir-update-time* *maildir-update-time*
-                          'update-maildir-infos)))
+	(setf *maildir-timer*
+		  (run-with-timer 0 *maildir-update-time* #'update-maildir-infos)))
   (loop for (label . info) in *maildir-info*
 		collect (stumpwm:format-expand `((#\l ,(constantly label))
 										 (#\n ,(lambda () (format nil "^[~A~D^]"
@@ -103,7 +91,7 @@ Temporary mails number
 										 (#\t ,(lambda () (format nil "~D" (getf info :tmp)))))
 									   *maildir-modeline-fmt*)
 		  into fmts
-		finally (return (format nil "~{~A~}" fmts))))
+		finally (return (apply #'concat fmts))))
 
 
 

--- a/modeline/maildir/maildir.lisp
+++ b/modeline/maildir/maildir.lisp
@@ -32,7 +32,7 @@
 									  (user-homedir-pathname))))
   "Alist of pathnames to the mail directories with names. Defaults to just ~/Mail.")
 
-(defvar *maildir-modeline-fmt* "[%l: %n] "
+(defvar *maildir-modeline-fmt* "%l: %n "
   "The Default Value For Displaying Maildir information on the modeline.
 
 @table @asis
@@ -52,8 +52,9 @@ Temporary mails number
 
 (defun maildir-mailboxes (maildir)
   "Returns a list of all mailboxes in *maildir-path*."
-  (directory (merge-pathnames (make-pathname :directory '(:relative :wild))
-							  maildir)))
+  (cons maildir (directory (merge-pathnames (make-pathname :directory
+														   '(:relative :wild))
+											maildir))))
 
 (defun maildir-mailbox-dir (mailbox dir-name)
   "Returns the specified sub-directory pathname for the provided mailbox."
@@ -84,8 +85,8 @@ Temporary mails number
 		  (run-with-timer 0 *maildir-update-time* #'update-maildir-infos)))
   (loop for (label . info) in *maildir-info*
 		collect (stumpwm:format-expand `((#\l ,(constantly label))
-										 (#\n ,(lambda () (format nil "^[~A~D^]"
-																  (if (plusp (getf info :new)) "^B" "")
+										 (#\n ,(lambda () (format nil "^[~@[^B~*~]~D^]"
+																  (plusp (getf info :new))
 																  (getf info :new))))
 										 (#\c ,(lambda () (format nil "~D" (getf info :cur))))
 										 (#\t ,(lambda () (format nil "~D" (getf info :tmp)))))


### PR DESCRIPTION
**Note:** I just started using StumpWM just over a week ago, so I might have messed up a few things. And haven't had that much experience with Common Lisp per se... but at least it works on my machine.

---

As the title says, changed the maildir module to support multiple maildirs -- at the cost of having to change the old interface. Mail changes are:
- changing the format string from `%M` to `%D` (Mail- **d** -ir, I know it's bad)
- substituting `*maildir-path*` for `*maildir-alist*`
- dropping a few older functions

I could imagine the possibility of adding backwards compatibility support, but there problem would be a very hack-y (in the bad sense) result that would a harder to hack around with (in the good sense).

I'm looking forward to criticism and improvments, but it will probably take a while (~1-2 weeks) to fix if these are really deep.