### PR TITLE
Make stumpish be well-behaved and return 0 upon success

### DIFF
--- a/util/stumpish/stumpish
+++ b/util/stumpish/stumpish
@@ -56,7 +56,7 @@ wait_result ()
 
     if echo "$RESULT" | grep -q '= $'
     then
-	return 1
+	return 0
     fi
 
     echo "$RESULT" |


### PR DESCRIPTION
Currently, if you run `stumpish` with a command argument (i.e. not interactively) and the command does not produce any output, `stumpish` returns 1, even though it returns successfully.

    $ stumpish vsplit
    $ echo $?
    1

This patch simply fixes this to be more inline with expected Unix behavior of returning 0 on success so `stumpish` will fit better when called from an external tool or script.