### PR TITLE
Add pass-copy-menu

### DIFF
--- a/util/pass/README.org
+++ b/util/pass/README.org
@@ -10,6 +10,8 @@ The following commands will become available:
 
 - =pass-copy=: select an entry to put into the
   clipboard. (Auto-completion is available.)
+- =pass-copy-menu=: select an entry from a menu to put into the
+  clipboard.
 - =pass-generate=: generate a password for a new given entry and put
   it into the clipboard.
 

--- a/util/pass/pass.lisp
+++ b/util/pass/pass.lisp
@@ -24,6 +24,14 @@
                                         (pass-entries))))
     (stumpwm:run-shell-command (format nil "pass -c ~a" entry))))
 
+(stumpwm:defcommand pass-copy-menu () ()
+  "Select a password entry from a menu and copy the password into the clipboard."
+  (let ((entry (stumpwm:select-from-menu
+                (stumpwm:current-screen)
+                (mapcar 'list (pass-entries))
+                "Copy password to clipboard: ")))
+    (stumpwm:run-shell-command (format nil "pass -c ~a" (car entry)))))
+
 (stumpwm:defcommand pass-generate () ()
   "Generate a password and put it into the clipboard"
   (let ((entry-name (stumpwm:read-one-line (stumpwm:current-screen)


### PR DESCRIPTION
When selecting a password to copy via `pass-copy` I often don't
remember the name under which I stored the password. Autocomplete in
`pass-copy` helps a bit, but I think a bit more visibility would be
nice.

This PR adds the function `pass-copy-menu`, which displays the
available password entries in a menu. The user can then select or
narrow down an entry via autocompletion.

@ralt Would you like to merge this?