### PR TITLE
Cycle MRU Module

### DIFF
--- a/README.org
+++ b/README.org
@@ -64,47 +64,48 @@ Advertise your module here, open a PR and include a org-mode link!
 (click for its respective README/docs)
 # Don't edit anything below this line, the script will blow it away
 # --
-** Utilities
-- [[./util/kbd-layouts/README.org][kbd-layouts]] :: Keyboard layout switcher for StumpWM
-- [[./util/pass/README.org][pass]] :: Integrate 'pass' with StumpWM
-- [[./util/urgentwindows/README.org][urgentwindows]] :: Allows focusing application windows that need user attention
-- [[./util/pinentry/README.org][pinentry]] :: Integrate GnuPG Agent with StumpWM
-- [[./util/swm-gaps/README.org][swm-gaps]] :: Pretty (useless) gaps for StumpWM
-- [[./util/app-menu/README.org][app-menu]] :: A simple application menu for launching shell commands
-- [[./util/globalwindows/README.org][globalwindows]] :: Manipulate all windows in the current X session
-- [[./util/notify/README.org][notify]] :: DBus-based notification server part
-- [[./util/windowtags/README.org][windowtags]] :: Add metadata to windows to manipulate them en mass.
-- [[./util/perwindowlayout/README.org][perwindowlayout]] :: Change the keyboard layout per window.
-- [[./util/searchengines/README.org][searchengines]] :: Allows searching text using prompt or clipboard contents with various search engines
-- [[./util/qubes/README.org][qubes]] :: Integration to Qubes OS (https://www.qubes-os.org)
-- [[./util/end-session/README.org][end-session]] :: Provides commands to stumpwm that allow the user to shutdown, restart, and logoff through the stumpwm UI
-- [[./util/productivity/README.org][productivity]] :: Lock StumpWM down so you have to get work done.
-- [[./util/ttf-fonts/README.org][ttf-fonts]] :: A pure lisp implementation of TTF font rendering.
-- [[./util/clipboard-history/README.org][clipboard-history]] :: Simple clipboard history module for StumpWM
-- [[./util/command-history/README.org][command-history]] :: Save and load the stumpwm::*input-history* to a file
-- [[./util/surfraw/README.org][surfraw]] :: Integrates surfraw with stumpwm.
-- [[./util/winner-mode/README.org][winner-mode]] :: Emacs' winner-mode for StumpWM
-- [[./util/logitech-g15-keysyms/README.org][logitech-g15-keysyms]] :: Describe logitech-g15-keysyms here
-- [[./util/screenshot/README.org][screenshot]] :: Takes screenshots and stores them as png files
-- [[./util/passwd/README.org][passwd]] :: A simple password utility based on ironclad.
-- [[./util/swm-emacs/README.org][swm-emacs]] :: A set of utilities for launching the beast.
-- [[./util/alert-me/README.org][alert-me]] :: Alert me that an event is coming
-- [[./util/numpad-layouts/README.org][numpad-layouts]] :: A module for handling different keyboards numpad layouts
-- [[./util/stumptray/README.org][stumptray]] :: System Tray for stumpwm.
-- [[./util/undocumented/README.org][undocumented]] :: Look for stuff that should probably be in the manual that isn't
-- [[./util/cycle-mru/README.org][cycle-mru]] :: Cycle windows in most recently used order.
-- [[./util/desktop-entry/README.org][desktop-entry]] :: desktop-entry
 ** Minor Modes
 - [[./minor-mode/mpd/README.org][mpd]] :: Displays information about the music player daemon (MPD).
 ** Modeline
 - [[./minor-mode/notifications/README.org][notifications]] :: A notification library that sends notifications to the modeline via stumpish or from stumpwm itself.
-- [[./modeline/disk/README.org][disk]] :: Display filesystem information in the modeline
-- [[./modeline/hostname/README.org][hostname]] :: Put hostname in the StumpWM modeline
-- [[./modeline/wifi/README.org][wifi]] :: Display information about your wifi.
-- [[./modeline/net/README.org][net]] :: Displays information about the current network connection.
-- [[./modeline/cpu/README.org][cpu]] :: Add cpu info to the modeline.
-- [[./modeline/mem/README.org][mem]] :: Display memory in the modeline, %M conflicts with maildir.
-- [[./modeline/battery-portable/README.org][battery-portable]] :: Add battery information to the modeline in a portable way.
-- [[./modeline/maildir/README.org][maildir]] :: Display maildir information in the modeline (%M conflicts with mem).
 ** Media
 - [[./media/amixer/README.org][amixer]] :: Manipulate the volume using amixer
+- [[./modeline/cpu/README.org][cpu]] :: Add cpu info to the modeline.
+- [[./modeline/sensors/README.org][sensors]] :: View CPU temperature and fan RPM in modeline
+- [[./modeline/maildir/README.org][maildir]] :: Display maildir information in the modeline (%M conflicts with mem).
+- [[./modeline/battery-portable/README.org][battery-portable]] :: Add battery information to the modeline in a portable way.
+- [[./modeline/disk/README.org][disk]] :: Display filesystem information in the modeline
+- [[./modeline/wifi/README.org][wifi]] :: Display information about your wifi.
+- [[./modeline/net/README.org][net]] :: Displays information about the current network connection.
+- [[./modeline/mem/README.org][mem]] :: Display memory in the modeline, %M conflicts with maildir.
+- [[./modeline/hostname/README.org][hostname]] :: Put hostname in the StumpWM modeline
+** Utilities
+- [[./util/windowtags/README.org][windowtags]] :: Add metadata to windows to manipulate them en mass.
+- [[./util/qubes/README.org][qubes]] :: Integration to Qubes OS (https://www.qubes-os.org)
+- [[./util/surfraw/README.org][surfraw]] :: Integrates surfraw with stumpwm.
+- [[./util/clipboard-history/README.org][clipboard-history]] :: Simple clipboard history module for StumpWM
+- [[./util/winner-mode/README.org][winner-mode]] :: Emacs' winner-mode for StumpWM
+- [[./util/passwd/README.org][passwd]] :: A simple password utility based on ironclad.
+- [[./util/notify/README.org][notify]] :: DBus-based notification server part
+- [[./util/undocumented/README.org][undocumented]] :: Look for stuff that should probably be in the manual that isn't
+- [[./util/alert-me/README.org][alert-me]] :: Alert me that an event is coming
+- [[./util/urgentwindows/README.org][urgentwindows]] :: Allows focusing application windows that need user attention
+- [[./util/desktop-entry/README.org][desktop-entry]] :: desktop-entry
+- [[./util/globalwindows/README.org][globalwindows]] :: Manipulate all windows in the current X session
+- [[./util/cycle-mru/README.org][cycle-mru]] :: Cycle windows in most recently used order.
+- [[./util/screenshot/README.org][screenshot]] :: Takes screenshots and stores them as png files
+- [[./util/searchengines/README.org][searchengines]] :: Allows searching text using prompt or clipboard contents with various search engines
+- [[./util/pinentry/README.org][pinentry]] :: Integrate GnuPG Agent with StumpWM
+- [[./util/perwindowlayout/README.org][perwindowlayout]] :: Change the keyboard layout per window.
+- [[./util/command-history/README.org][command-history]] :: Save and load the stumpwm::*input-history* to a file
+- [[./util/pass/README.org][pass]] :: Integrate 'pass' with StumpWM
+- [[./util/stumptray/README.org][stumptray]] :: System Tray for stumpwm.
+- [[./util/end-session/README.org][end-session]] :: Provides commands to stumpwm that allow the user to shutdown, restart, and logoff through the stumpwm UI
+- [[./util/kbd-layouts/README.org][kbd-layouts]] :: Keyboard layout switcher for StumpWM
+- [[./util/ttf-fonts/README.org][ttf-fonts]] :: A pure lisp implementation of TTF font rendering.
+- [[./util/productivity/README.org][productivity]] :: Lock StumpWM down so you have to get work done.
+- [[./util/numpad-layouts/README.org][numpad-layouts]] :: A module for handling different keyboards numpad layouts
+- [[./util/swm-gaps/README.org][swm-gaps]] :: Pretty (useless) gaps for StumpWM
+- [[./util/swm-emacs/README.org][swm-emacs]] :: A set of utilities for launching the beast.
+- [[./util/logitech-g15-keysyms/README.org][logitech-g15-keysyms]] :: Describe logitech-g15-keysyms here
+- [[./util/app-menu/README.org][app-menu]] :: A simple application menu for launching shell commands

--- a/README.org
+++ b/README.org
@@ -65,45 +65,46 @@ Advertise your module here, open a PR and include a org-mode link!
 # Don't edit anything below this line, the script will blow it away
 # --
 ** Utilities
-- [[./util/ttf-fonts/README.org][ttf-fonts]] :: A pure lisp implementation of TTF font rendering.
 - [[./util/kbd-layouts/README.org][kbd-layouts]] :: Keyboard layout switcher for StumpWM
-- [[./util/screenshot/README.org][screenshot]] :: Takes screenshots and stores them as png files
-- [[./util/alert-me/README.org][alert-me]] :: Alert me that an event is coming
-- [[./util/ft2-fonts/README.org][ft2-fonts]] :: An implementation of font rendering that allows users to select OTF/TTF fonts using FreeType rendering.
-- [[./util/winner-mode/README.org][winner-mode]] :: Emacs' winner-mode for StumpWM
-- [[./util/windowtags/README.org][windowtags]] :: Add metadata to windows to manipulate them en mass.
-- [[./util/end-session/README.org][end-session]] :: Provides commands to stumpwm that allow the user to shutdown, restart, and logoff through the stumpwm UI
-- [[./util/notify/README.org][notify]] :: DBus-based notification server part
-- [[./util/qubes/README.org][qubes]] :: Integration to Qubes OS (https://www.qubes-os.org)
-- [[./util/stumptray/README.org][stumptray]] :: System Tray for stumpwm.
-- [[./util/numpad-layouts/README.org][numpad-layouts]] :: A module for handling different keyboards numpad layouts
-- [[./util/clipboard-history/README.org][clipboard-history]] :: Simple clipboard history module for StumpWM
-- [[./util/globalwindows/README.org][globalwindows]] :: Manipulate all windows in the current X session
-- [[./util/urgentwindows/README.org][urgentwindows]] :: Allows focusing application windows that need user attention
-- [[./util/swm-gaps/README.org][swm-gaps]] :: Pretty (useless) gaps for StumpWM
-- [[./util/searchengines/README.org][searchengines]] :: Allows searching text using prompt or clipboard contents with various search engines
-- [[./util/command-history/README.org][command-history]] :: Save and load the stumpwm::*input-history* to a file
-- [[./util/logitech-g15-keysyms/README.org][logitech-g15-keysyms]] :: Describe logitech-g15-keysyms here
 - [[./util/pass/README.org][pass]] :: Integrate 'pass' with StumpWM
+- [[./util/urgentwindows/README.org][urgentwindows]] :: Allows focusing application windows that need user attention
+- [[./util/pinentry/README.org][pinentry]] :: Integrate GnuPG Agent with StumpWM
+- [[./util/swm-gaps/README.org][swm-gaps]] :: Pretty (useless) gaps for StumpWM
+- [[./util/app-menu/README.org][app-menu]] :: A simple application menu for launching shell commands
+- [[./util/globalwindows/README.org][globalwindows]] :: Manipulate all windows in the current X session
+- [[./util/notify/README.org][notify]] :: DBus-based notification server part
+- [[./util/windowtags/README.org][windowtags]] :: Add metadata to windows to manipulate them en mass.
+- [[./util/perwindowlayout/README.org][perwindowlayout]] :: Change the keyboard layout per window.
+- [[./util/searchengines/README.org][searchengines]] :: Allows searching text using prompt or clipboard contents with various search engines
+- [[./util/qubes/README.org][qubes]] :: Integration to Qubes OS (https://www.qubes-os.org)
+- [[./util/end-session/README.org][end-session]] :: Provides commands to stumpwm that allow the user to shutdown, restart, and logoff through the stumpwm UI
+- [[./util/productivity/README.org][productivity]] :: Lock StumpWM down so you have to get work done.
+- [[./util/ttf-fonts/README.org][ttf-fonts]] :: A pure lisp implementation of TTF font rendering.
+- [[./util/clipboard-history/README.org][clipboard-history]] :: Simple clipboard history module for StumpWM
+- [[./util/command-history/README.org][command-history]] :: Save and load the stumpwm::*input-history* to a file
 - [[./util/surfraw/README.org][surfraw]] :: Integrates surfraw with stumpwm.
+- [[./util/winner-mode/README.org][winner-mode]] :: Emacs' winner-mode for StumpWM
+- [[./util/logitech-g15-keysyms/README.org][logitech-g15-keysyms]] :: Describe logitech-g15-keysyms here
+- [[./util/screenshot/README.org][screenshot]] :: Takes screenshots and stores them as png files
 - [[./util/passwd/README.org][passwd]] :: A simple password utility based on ironclad.
 - [[./util/swm-emacs/README.org][swm-emacs]] :: A set of utilities for launching the beast.
-- [[./util/pinentry/README.org][pinentry]] :: Integrate GnuPG Agent with StumpWM
-- [[./util/app-menu/README.org][app-menu]] :: A simple application menu for launching shell commands
-- [[./util/perwindowlayout/README.org][perwindowlayout]] :: Change the keyboard layout per window.
+- [[./util/alert-me/README.org][alert-me]] :: Alert me that an event is coming
+- [[./util/numpad-layouts/README.org][numpad-layouts]] :: A module for handling different keyboards numpad layouts
+- [[./util/stumptray/README.org][stumptray]] :: System Tray for stumpwm.
 - [[./util/undocumented/README.org][undocumented]] :: Look for stuff that should probably be in the manual that isn't
-- [[./util/productivity/README.org][productivity]] :: Lock StumpWM down so you have to get work done.
-** Media
-- [[./media/amixer/README.org][amixer]] :: Manipulate the volume using amixer
-** Modeline
-- [[./modeline/hostname/README.org][hostname]] :: Put hostname in the StumpWM modeline
-- [[./modeline/cpu/README.org][cpu]] :: Add cpu info to the modeline.
-- [[./modeline/battery-portable/README.org][battery-portable]] :: Add battery information to the modeline in a portable way.
-- [[./modeline/disk/README.org][disk]] :: Display filesystem information in the modeline
-- [[./modeline/maildir/README.org][maildir]] :: Display maildir information in the modeline (%M conflicts with mem).
-- [[./modeline/mem/README.org][mem]] :: Display memory in the modeline, %M conflicts with maildir.
-- [[./modeline/wifi/README.org][wifi]] :: Display information about your wifi.
-- [[./modeline/net/README.org][net]] :: Displays information about the current network connection.
+- [[./util/cycle-mru/README.org][cycle-mru]] :: Cycle windows in most recently used order.
+- [[./util/desktop-entry/README.org][desktop-entry]] :: desktop-entry
 ** Minor Modes
 - [[./minor-mode/mpd/README.org][mpd]] :: Displays information about the music player daemon (MPD).
+** Modeline
 - [[./minor-mode/notifications/README.org][notifications]] :: A notification library that sends notifications to the modeline via stumpish or from stumpwm itself.
+- [[./modeline/disk/README.org][disk]] :: Display filesystem information in the modeline
+- [[./modeline/hostname/README.org][hostname]] :: Put hostname in the StumpWM modeline
+- [[./modeline/wifi/README.org][wifi]] :: Display information about your wifi.
+- [[./modeline/net/README.org][net]] :: Displays information about the current network connection.
+- [[./modeline/cpu/README.org][cpu]] :: Add cpu info to the modeline.
+- [[./modeline/mem/README.org][mem]] :: Display memory in the modeline, %M conflicts with maildir.
+- [[./modeline/battery-portable/README.org][battery-portable]] :: Add battery information to the modeline in a portable way.
+- [[./modeline/maildir/README.org][maildir]] :: Display maildir information in the modeline (%M conflicts with mem).
+** Media
+- [[./media/amixer/README.org][amixer]] :: Manipulate the volume using amixer

--- a/modeline/sensors/README.org
+++ b/modeline/sensors/README.org
@@ -4,13 +4,13 @@ View CPU temperature and fan RPM in the modeline.
 
 ** PRE-REQUISITES
 
-Running Linux with `lm-sensors` installed.
+Running Linux with ~lm-sensors~ installed.
 
 ** USAGE
 
-To load this module, place `(load-module sensors)` in your `.stumpwmrc`.
+To load this module, place ~(load-module sensors)~ in your ~.stumpwmrc~.
 
-Sensors information is then available to display in the modeline using `%S` in
+Sensors information is then available to display in the modeline using ~%S~ in
 your modeline config.
 
 As an example, here is my modeline config:
@@ -29,14 +29,14 @@ setting.
 
 ** CAVEATS
 
-This only displays the cpu of one core and the fan info. Much more is available
-with the sensors command. I'd welcome any patches that made the package more
-dynamic and configurable in this respect...
+This only displays the CPU temperature (~Package id 0~) and the fan RPM
+speed. Much more is available with the sensors command. I'd welcome any patches
+that made the package more dynamic and configurable in this respect...
 
 Also, I'm very new to Common Lisp, so the code is pretty hacky. I'd welcome any
 advice on how to make it better.
 
 ** EXTRA
 
-As an extra bonus this module contains the stumpwm command `sensors` for viewing
+As an extra bonus this module contains the stumpwm command ~sensors~ for viewing
 the same information in a message window.

--- a/modeline/sensors/README.org
+++ b/modeline/sensors/README.org
@@ -36,6 +36,9 @@ that made the package more dynamic and configurable in this respect...
 Also, I'm very new to Common Lisp, so the code is pretty hacky. I'd welcome any
 advice on how to make it better.
 
+Also credit must go to the author of [[https://github.com/tslight/stumpwm-contrib/tree/master/modeline/battery-portable][Battery Portable]] for the ~*refresh-time*~
+logic.
+
 ** EXTRA
 
 As an extra bonus this module contains the stumpwm command ~sensors~ for viewing

--- a/modeline/sensors/README.org
+++ b/modeline/sensors/README.org
@@ -1,0 +1,42 @@
+* MODELINE SENSORS DISPLAY
+
+View CPU temperature and fan RPM in the modeline.
+
+** PRE-REQUISITES
+
+Running Linux with `lm-sensors` installed.
+
+** USAGE
+
+To load this module, place `(load-module sensors)` in your `.stumpwmrc`.
+
+Sensors information is then available to display in the modeline using `%S` in
+your modeline config.
+
+As an example, here is my modeline config:
+
+#+BEGIN_SRC common-lisp
+  (setf *screen-mode-line-format*
+        (list "^3^B%d ^2[%n] ^7%v ^n ^> %S %T"))
+#+END_SRC
+
+You can change the default refresh time of 30 seconds with the following
+setting.
+
+#+BEGIN_SRC common-lisp
+(setf stumpwm.contrib.sensors:*refresh-time* nil)
+#+END_SRC
+
+** CAVEATS
+
+This only displays the cpu of one core and the fan info. Much more is available
+with the sensors command. I'd welcome any patches that made the package more
+dynamic and configurable in this respect...
+
+Also, I'm very new to Common Lisp, so the code is pretty hacky. I'd welcome any
+advice on how to make it better.
+
+** EXTRA
+
+As an extra bonus this module contains the stumpwm command `sensors` for viewing
+the same information in a message window.

--- a/modeline/sensors/package.lisp
+++ b/modeline/sensors/package.lisp
@@ -1,0 +1,5 @@
+;;;; package.lisp
+
+(defpackage #:sensors
+  (:use #:cl #:stumpwm)
+  (:export #:*refresh-time*))

--- a/modeline/sensors/package.lisp
+++ b/modeline/sensors/package.lisp
@@ -1,5 +1,5 @@
 ;;;; package.lisp
 
 (defpackage #:sensors
-  (:use #:cl #:stumpwm)
+  (:use #:cl #:stumpwm #:cl-ppcre)
   (:export #:*refresh-time*))

--- a/modeline/sensors/package.lisp
+++ b/modeline/sensors/package.lisp
@@ -2,4 +2,11 @@
 
 (defpackage #:sensors
   (:use #:cl #:stumpwm #:cl-ppcre)
-  (:export #:*refresh-time*))
+  (:export #:*refresh-time*
+	   #:*red-above-temp*
+	   #:*yellow-above-temp*
+	   #:*display-above-temp*
+	   #:*red-above-rpm*
+	   #:*yellow-above-rpm*
+	   #:*display-above-rpm*
+	   #:*ignore-below*))

--- a/modeline/sensors/sensors.asd
+++ b/modeline/sensors/sensors.asd
@@ -1,0 +1,11 @@
+;;;; sensors.asd
+
+(asdf:defsystem #:sensors
+  :description "View CPU temperature and fan RPM in modeline"
+  :author "Toby Slight <tslight@pm.me>"
+  :license  "GPLv3"
+  :version "0.0.1"
+  :serial t
+  :depends-on (#:stumpwm)
+  :components ((:file "package")
+	       (:file "sensors")))

--- a/modeline/sensors/sensors.lisp
+++ b/modeline/sensors/sensors.lisp
@@ -26,8 +26,14 @@
 	 (temps (sensors-as-ints output *temp-regex*))
 	 (fans (sensors-as-ints output *fan-regex*))
 	 (max-temp (reduce #'max temps))
-	 (avg-temp (floor (apply #'+ temps) (length temps)))
-	 (avg-rpm (floor (apply #'+ fans) (length fans))))
+	 (avg-temp
+	  (handler-case
+	      (floor (apply #'+ temps) (length temps))
+	    (division-by-zero () 0)))
+	 (avg-rpm
+	  (handler-case
+	      (floor (apply #'+ fans) (length fans))
+	    (division-by-zero () 0))))
     (if as-string
 	(concat
 	 (write-to-string max-temp) (string (code-char 176)) "C "

--- a/modeline/sensors/sensors.lisp
+++ b/modeline/sensors/sensors.lisp
@@ -79,7 +79,7 @@
     (concat
      (if max-temp (concat max-temp (string (code-char 176)) "C^n"))
      (if avg-temp (concat " " avg-temp (string (code-char 176)) "C^n"))
-     (if avg-rpm (concat " " avg-temp "RPM^n")))))
+     (if avg-rpm (concat " " avg-rpm " RPM^n")))))
 
 (defcommand sensors-message () ()
   (message (sensors)))

--- a/modeline/sensors/sensors.lisp
+++ b/modeline/sensors/sensors.lisp
@@ -1,0 +1,61 @@
+;;;; sensors.lisp
+
+(in-package #:sensors)
+
+(defvar *refresh-time* 30
+  "Time in seconds between updates of sensors information.")
+
+(defun get-cpu-temp (output)
+  "Rips out the the value of the Package id 0 row from the OUTPUT of the sensors
+   command. Adds color depending on it's value when converted to an int."
+  (let* ((start (search "Package id 0:" output))
+	 (end (search "(high" output))
+	 (cpu-temp (subseq output start end))
+	 (cpu-temp (string-trim "Package id 0: +" cpu-temp))
+	 (int (parse-integer (remove-if #'alpha-char-p cpu-temp) :junk-allowed t)))
+    (cond ((< 60 int) (concat "^1*" cpu-temp "^n"))
+	  ((< 50 int) (concat "^3*" cpu-temp "^n"))
+	  (t cpu-temp))))
+
+(defun get-fan-rpm (output)
+  "Rips out the value of the exhaust row from the OUTPUT of the sensors
+  command. Adds color depending on it's value when converted to an int."
+  (let* ((start (search "Exhaust" output))
+	 (end (search "(min" output))
+	 (fan-rpm (subseq output start end))
+	 (fan-rpm (string-trim "Exhaust :" fan-rpm))
+	 (int (parse-integer (remove-if #'alpha-char-p fan-rpm) :junk-allowed t)))
+    (cond ((< 3500 int) (concat "^1*" fan-rpm "^n"))
+	  ((< 2500 int) (concat "^3*" fan-rpm "^n"))
+	  (t fan-rpm))))
+
+(defun get-sensors (&optional as-string)
+  "Gets a large string back from running sensors in the shell, and then parses
+   out a CPU temperature value and fan RPM using get-cpu-temp and get-fan-rpm.
+   Takes optional AS-STRING boolean which if true returns output as formatted
+   string."
+  (let* ((output (run-shell-command "sensors" t))
+	 (cpu-temp (get-cpu-temp output))
+	 (fan-rpm (get-fan-rpm output)))
+    (if as-string
+	(concat cpu-temp " " fan-rpm)
+	(list cpu-temp fan-rpm))))
+
+(defcommand sensors () ()
+	    (let* ((my-sensors (get-sensors))
+		   (cpu-temp (nth 0 my-sensors))
+		   (fan-rpm (nth 1 my-sensors)))
+	      (message "^B^5CPU: ^n~a~%^B^5FAN: ^n~a" cpu-temp fan-rpm)))
+
+;; pinched from battery portable code
+(let ((next 0)
+      (last-value ""))
+  (defun fmt-sensors (ml)
+    (declare (ignore ml))
+    (let ((now (get-universal-time)))
+      (when (< now next)
+	(return-from fmt-sensors last-value))
+      (setf next (+ now *refresh-time*)))
+    (setf last-value (get-sensors t))))
+
+(add-screen-mode-line-formatter #\S #'fmt-sensors)

--- a/modeline/sensors/sensors.lisp
+++ b/modeline/sensors/sensors.lisp
@@ -11,14 +11,23 @@
 (defvar *fan-regex* "(?<=\\:).*?(?=RPM)"
   "A regex that captures all fans.")
 
-(defvar *red-above* 60
+(defvar *red-above-temp* 60
   "Temperature to turn red at.")
 
-(defvar *yellow-above* 50
+(defvar *yellow-above-temp* 50
   "Temperature to turn yellow at.")
 
-(defvar *display-above* 40
+(defvar *display-above-temp* 40
   "Temperature to start displaying at.")
+
+(defvar *red-above-rpm* 4000
+  "Fan RPM to turn red at.")
+
+(defvar *yellow-above-rpm* 3000
+  "Fan RPM to turn yellow at.")
+
+(defvar *display-above-rpm* 2000
+  "Fan RPM to start displaying at.")
 
 (defvar *ignore-below* 20
   "Ignore temperatures below this temperature when calculating average.")
@@ -35,9 +44,9 @@
 
 (defun get-colors (value
 		   &optional
-		     (high *red-above*)
-		     (mid *yellow-above*)
-		     (low *display-above*))
+		     (high *red-above-temp*)
+		     (mid *yellow-above-temp*)
+		     (low *display-above-temp*))
   (cond ((< high value) (concat "^1*" (write-to-string value)))
 	((< mid value) (concat "^3*" (write-to-string value)))
 	((< low value) (write-to-string value))
@@ -56,7 +65,7 @@
 		   (handler-case
 		       (floor (apply #'+ fans) (length fans))
 		     (division-by-zero () 0))
-		   4000 3000 2000)))
+		   *red-above-rpm* *yellow-above-rpm* *display-above-rpm*)))
     (concat
      (if max-temp (concat max-temp (string (code-char 176)) "C^n"))
      (if avg-temp (concat " " avg-temp (string (code-char 176)) "C^n"))

--- a/modeline/sensors/sensors.lisp
+++ b/modeline/sensors/sensors.lisp
@@ -33,6 +33,8 @@
   "A regex that captures all fans.")
 
 (defun sensors-as-ints (output regex)
+  "Use REGEX to extract sensor values from OUTPUT, and then cast them to a list
+   of integers if they are greater than *IGNORE-BELOW*."
   (let ((strings (ppcre:all-matches-as-strings regex output)))
     (mapcan ;; https://stackoverflow.com/a/13269952
      (lambda (s)
@@ -47,12 +49,20 @@
 		     (high *red-above-temp*)
 		     (mid *yellow-above-temp*)
 		     (low *display-above-temp*))
+  "If VALUE is greater than HIGH, MID or LOW, return it as a red, yellow or
+   normal coloured string, respectively. If value is lower than LOW, don't
+   return anything."
   (cond ((< high value) (concat "^1*" (write-to-string value)))
 	((< mid value) (concat "^3*" (write-to-string value)))
 	((< low value) (write-to-string value))
 	(t nil)))
 
 (defun sensors ()
+  "Transforms the output of the sensors command into two lists of integers. One
+   for temperatures and one for fan speeds. Calculate the average values of the
+   lists (and the maximum for temperatures), then cast those values back to
+   strings with appropriate color formatting. Finally concatenate those strings
+   into one line."
   (let* ((output (run-shell-command "sensors" t))
 	 (temps (sensors-as-ints output *temp-regex*))
 	 (fans (sensors-as-ints output *fan-regex*))

--- a/modeline/sensors/sensors.lisp
+++ b/modeline/sensors/sensors.lisp
@@ -5,6 +5,12 @@
 (defvar *refresh-time* 30
   "Time in seconds between updates of sensors information.")
 
+(defvar *cpu-regex* "(?<=\\+).*[0-9]+.*C(?=.*\\()"
+  "A regex that captures all temperatures.")
+
+(defvar *fan-regex* "(?<=\\:).*[0-9]+.*RPM"
+  "A regex that captures all fans.")
+
 (defun get-sensor (output start-string end-string upper-bound lower-bound)
   "Rips out the the value of a sensors row from the OUTPUT from the sensors
    command, using a START-STRING and END-STRING that mark the place of the

--- a/modeline/sensors/sensors.lisp
+++ b/modeline/sensors/sensors.lisp
@@ -11,6 +11,15 @@
 (defvar *fan-regex* "(?<=\\:).*?(?=RPM)"
   "A regex that captures all fans.")
 
+(defvar *red-above* 60
+  "Temperature to turn red at.")
+
+(defvar *yellow-above* 50
+  "Temperature to turn yellow at.")
+
+(defvar *display-above* 40
+  "Temperature to start displaying at.")
+
 (defvar *ignore-below* 20
   "Ignore temperatures below this temperature when calculating average.")
 
@@ -24,44 +33,37 @@
 	     (list i))))
      strings)))
 
-(defun get-colors (value high mid low)
+(defun get-colors (value
+		   &optional
+		     (high *red-above*)
+		     (mid *yellow-above*)
+		     (low *display-above*))
   (cond ((< high value) (concat "^1*" (write-to-string value)))
 	((< mid value) (concat "^3*" (write-to-string value)))
 	((< low value) (write-to-string value))
 	(t nil)))
 
-(defun get-sensors (&optional as-string)
+(defun get-sensors ()
   (let* ((output (run-shell-command "sensors" t))
 	 (temps (sensors-as-ints output *temp-regex*))
 	 (fans (sensors-as-ints output *fan-regex*))
-	 (max-temp (get-colors (reduce #'max temps) 60 50 40))
+	 (max-temp (get-colors (reduce #'max temps)))
 	 (avg-temp (get-colors
 		    (handler-case
 			(floor (apply #'+ temps) (length temps))
-		      (division-by-zero () 0))
-		    60 50 40))
+		      (division-by-zero () 0))))
 	 (avg-rpm (get-colors
 		   (handler-case
 		       (floor (apply #'+ fans) (length fans))
 		     (division-by-zero () 0))
 		   4000 3000 2000)))
-    (if as-string
-	(concat
-	 (if max-temp (concat max-temp (string (code-char 176))) "C^n ")
-	 (if avg-temp (concat avg-temp (string (code-char 176))) "C^n ")
-	 (if avg-rpm (concat avg-temp "RPM^n")))
-	(list max-temp avg-temp avg-rpm))))
+    (concat
+     (if max-temp (concat max-temp (string (code-char 176)) "C^n"))
+     (if avg-temp (concat " " avg-temp (string (code-char 176)) "C^n"))
+     (if avg-rpm (concat " " avg-temp "RPM^n")))))
 
 (defcommand sensors () ()
-  (let* ((s (get-sensors))
-	 (max-temp (nth 0 s))
-	 (avg-temp (nth 1 s))
-	 (avg-rpm (nth 2 s)))
-    (message (concat
-	      "^B^5MAXIMUM TEMPERATURE: ^n~a" (string (code-char 176)) "C~%"
-	      "^B^5AVERAGE TEMPERATURE: ^n~a" (string (code-char 176)) "C~%"
-	      "^B^5AVERAGE FAN SPEED: ^n~a RPM")
-	     max-temp avg-temp avg-rpm)))
+  (message (get-sensors)))
 
 ;; pinched from battery portable code
 (let ((next 0)
@@ -72,6 +74,6 @@
       (when (< now next)
 	(return-from fmt-sensors last-value))
       (setf next (+ now *refresh-time*)))
-    (setf last-value (get-sensors t))))
+    (setf last-value (get-sensors))))
 
 (add-screen-mode-line-formatter #\S #'fmt-sensors)

--- a/util/cycle-mru/README.org
+++ b/util/cycle-mru/README.org
@@ -1,0 +1,32 @@
+* Cycle MRU
+
+Cycle windows in most recently used order.
+
+** Description
+
+Flip through a group's windows, in a fashion similar to Window's Alt-Tab or
+macOS' Command-Tab. A.K.A. Most Recently Used order.
+
+This code was lifted from [[http://nongnu.13855.n7.nabble.com/Alt-Tab-td127943.html][this thread]] on the stumpwm-devel mailing list from way
+back in 2012.
+
+I have made some minor aesthetic and semantic changes to it (ie - changing the
+name from alt-tab to cycle-mru), but full credit goes to Ruthard Baudach for the
+code.
+
+I am a complete noob when it comes to lisp, so any improvements would be greatly
+appreciated, as would any tips on how to implement the stuff on the todo list
+below.
+
+** Usage
+
+#+BEGIN_SRC common-lisp
+(load-module "cycle-mru")
+(define-key *top-map* (kbd "M-Tab") "cycle-mru")
+#+END_SRC
+
+** Todo
+
+- Use windowlist to choose, and only select on release.
+- Implement reverse cycle.
+- Preserve tab list during group change.

--- a/util/cycle-mru/cycle-mru.asd
+++ b/util/cycle-mru/cycle-mru.asd
@@ -1,0 +1,11 @@
+;;;; cycle-mru.asd
+
+(asdf:defsystem #:cycle-mru
+  :description "Cycle windows in most recently used order."
+  :author "Toby Slight"
+  :license  "GPLv3"
+  :version "0.0.1"
+  :serial t
+  :depends-on (#:stumpwm)
+  :components ((:file "package")
+	       (:file "cycle-mru")))

--- a/util/cycle-mru/cycle-mru.lisp
+++ b/util/cycle-mru/cycle-mru.lisp
@@ -1,0 +1,63 @@
+;;;; cycle-mru.lisp
+
+(in-package #:cycle-mru)
+
+(defun get-milliseconds () ()
+       "Get timestamp in milliseconds."
+       (floor (* 1000 (/ (get-internal-real-time)
+			 internal-time-units-per-second))))
+
+(defun mru-new-window (win) ()
+       "Function called by new-window-hook. Updates mru-list."
+       (push (window-number win)  *mru-list*))
+
+(defun mru-destroy-window (win) ()
+       "Function called by destroy-window-hook. Deletes window number from
+	mru-list."
+       (setf *mru-list* (delete (window-number win) *mru-list*)))
+
+(defun mru-focus-window (new-win old-win) ()
+       "Function called by focus-window-hook. Updates mru-list."
+       (when new-win
+	 (setf *mru-list* (delete (window-number new-win) *mru-list*)))
+       (when old-win
+	 (push (window-number old-win) *mru-list*)))
+
+(defun mru-focus-group (to-group from-group) ()
+       "Handling group switching."
+       (setf *mru-list* (mapcar 'window-number (group-windows to-group))))
+
+(setf *new-window-hook* (list 'mru-new-window))
+(setf *destroy-window-hook* (list 'mru-destroy-window))
+(setf *focus-window-hook* (list 'mru-focus-window))
+(setf *focus-group-hook* (list 'mru-focus-group))
+
+(defvar *mru-list* (make-list 0))
+(defvar *mru-cycle* (make-list 0))
+(defvar *mru-timeout* 500) ; in milliseconds
+(defvar *mru-index* 0)     ; in milliseconds
+(defvar *mru-last-call* (get-milliseconds))
+
+(defcommand cycle-mru () ()
+  "Focus next windows according to most recently used order."
+  (cond
+    ;; if we're still in timeout
+    ((< (- (get-milliseconds) *mru-last-call*) 500)
+     ;; cycle through windows
+     (setf *mru-index* (mod (1+ *mru-index*) (list-length *mru-cycle*)))
+     (select-window-by-number (nth *mru-index* *mru-cycle*)))
+    ;; else start anew
+    (
+     (setf *mru-index* 1)
+     (setf *mru-cycle* (copy-list *mru-list*))
+     ;; if we've focussed a frame without window, current-window will return nil
+     ;; => select last used
+     (cond
+       ((not (current-window))
+	(select-window-by-number (first *mru-cycle*)))
+       (
+	(push (window-number (current-window)) *mru-cycle*)
+	(select-window-by-number (second *mru-cycle*))))))
+
+  ;; update timestamp
+  (setf *mru-last-call* (get-milliseconds)))

--- a/util/cycle-mru/cycle-mru.lisp
+++ b/util/cycle-mru/cycle-mru.lisp
@@ -42,16 +42,14 @@
      (setf *mru-index* (mod (1+ *mru-index*) (list-length *mru-cycle*)))
      (stumpwm:select-window-by-number (nth *mru-index* *mru-cycle*)))
     ;; else start anew
-    (
-     (setf *mru-index* 1)
+    ((setf *mru-index* 1)
      (setf *mru-cycle* (copy-list *mru-list*))
-     ;; if we've focussed a frame without window, current-window will return nil
-     ;; => select last used
+     ;; if we've focussed a frame without window, current-window will
+     ;; return nil => select last used
      (cond
        ((not (stumpwm:current-window))
 	(stumpwm:select-window-by-number (first *mru-cycle*)))
-       (
-	(push (stumpwm:window-number (stumpwm:current-window)) *mru-cycle*)
+       ((push (stumpwm:window-number (stumpwm:current-window)) *mru-cycle*)
 	(stumpwm:select-window-by-number (second *mru-cycle*))))))
 
   ;; update timestamp

--- a/util/cycle-mru/cycle-mru.lisp
+++ b/util/cycle-mru/cycle-mru.lisp
@@ -4,8 +4,9 @@
 
 (defun get-milliseconds () ()
        "Get timestamp in milliseconds."
-       (floor (* 1000 (/ (get-internal-real-time)
-			 internal-time-units-per-second))))
+       (floor
+	(* 1000
+	   (/ (get-internal-real-time) internal-time-units-per-second))))
 
 (defvar *mru-last-call* (get-milliseconds))
 (defvar *mru-list* (make-list 0))
@@ -37,7 +38,7 @@
   "Focus next windows according to most recently used order."
   (cond
     ;; if we're still in timeout
-    ((< (- (get-milliseconds) *mru-last-call*) 400)
+    ((< (- (get-milliseconds) *mru-last-call*) *mru-timeout*)
      ;; cycle through windows
      (setf *mru-index* (mod (1+ *mru-index*) (list-length *mru-cycle*)))
      (stumpwm:select-window-by-number (nth *mru-index* *mru-cycle*)))
@@ -51,6 +52,5 @@
 	(stumpwm:select-window-by-number (first *mru-cycle*)))
        ((push (stumpwm:window-number (stumpwm:current-window)) *mru-cycle*)
 	(stumpwm:select-window-by-number (second *mru-cycle*))))))
-
   ;; update timestamp
   (setf *mru-last-call* (get-milliseconds)))

--- a/util/cycle-mru/cycle-mru.lisp
+++ b/util/cycle-mru/cycle-mru.lisp
@@ -7,45 +7,40 @@
        (floor (* 1000 (/ (get-internal-real-time)
 			 internal-time-units-per-second))))
 
-(defun mru-new-window (win) ()
-       "Function called by new-window-hook. Updates mru-list."
-       (push (window-number win)  *mru-list*))
-
-(defun mru-destroy-window (win) ()
-       "Function called by destroy-window-hook. Deletes window number from
-	mru-list."
-       (setf *mru-list* (delete (window-number win) *mru-list*)))
-
-(defun mru-focus-window (new-win old-win) ()
-       "Function called by focus-window-hook. Updates mru-list."
-       (when new-win
-	 (setf *mru-list* (delete (window-number new-win) *mru-list*)))
-       (when old-win
-	 (push (window-number old-win) *mru-list*)))
-
-(defun mru-focus-group (to-group from-group) ()
-       "Handling group switching."
-       (setf *mru-list* (mapcar 'window-number (group-windows to-group))))
-
-(setf *new-window-hook* (list 'mru-new-window))
-(setf *destroy-window-hook* (list 'mru-destroy-window))
-(setf *focus-window-hook* (list 'mru-focus-window))
-(setf *focus-group-hook* (list 'mru-focus-group))
-
+(defvar *mru-last-call* (get-milliseconds))
 (defvar *mru-list* (make-list 0))
 (defvar *mru-cycle* (make-list 0))
 (defvar *mru-timeout* 500) ; in milliseconds
 (defvar *mru-index* 0)     ; in milliseconds
-(defvar *mru-last-call* (get-milliseconds))
 
-(defcommand cycle-mru () ()
+(defun mru-new-window (win) ()
+       "Function called by new-window-hook. Updates mru-list."
+       (push (stumpwm:window-number win) *mru-list*))
+
+(defun mru-destroy-window (win) ()
+       "Function called by destroy-window-hook. Deletes window number from
+	mru-list."
+       (setf *mru-list* (delete (stumpwm:window-number win) *mru-list*)))
+
+(defun mru-focus-window (new-win old-win) ()
+       "Function called by focus-window-hook. Updates mru-list."
+       (when new-win
+	 (setf *mru-list* (delete (stumpwm:window-number new-win) *mru-list*)))
+       (when old-win
+	 (push (stumpwm:window-number old-win) *mru-list*)))
+
+(setf stumpwm:*new-window-hook* (list 'mru-new-window))
+(setf stumpwm:*destroy-window-hook* (list 'mru-destroy-window))
+(setf stumpwm:*focus-window-hook* (list 'mru-focus-window))
+
+(stumpwm:defcommand cycle-mru () ()
   "Focus next windows according to most recently used order."
   (cond
     ;; if we're still in timeout
-    ((< (- (get-milliseconds) *mru-last-call*) 500)
+    ((< (- (get-milliseconds) *mru-last-call*) 400)
      ;; cycle through windows
      (setf *mru-index* (mod (1+ *mru-index*) (list-length *mru-cycle*)))
-     (select-window-by-number (nth *mru-index* *mru-cycle*)))
+     (stumpwm:select-window-by-number (nth *mru-index* *mru-cycle*)))
     ;; else start anew
     (
      (setf *mru-index* 1)
@@ -53,11 +48,11 @@
      ;; if we've focussed a frame without window, current-window will return nil
      ;; => select last used
      (cond
-       ((not (current-window))
-	(select-window-by-number (first *mru-cycle*)))
+       ((not (stumpwm:current-window))
+	(stumpwm:select-window-by-number (first *mru-cycle*)))
        (
-	(push (window-number (current-window)) *mru-cycle*)
-	(select-window-by-number (second *mru-cycle*))))))
+	(push (stumpwm:window-number (stumpwm:current-window)) *mru-cycle*)
+	(stumpwm:select-window-by-number (second *mru-cycle*))))))
 
   ;; update timestamp
   (setf *mru-last-call* (get-milliseconds)))

--- a/util/cycle-mru/package.lisp
+++ b/util/cycle-mru/package.lisp
@@ -1,0 +1,4 @@
+;;;; package.lisp
+
+(defpackage #:cycle-mru
+  (:use #:cl))

--- a/util/cycle-mru/package.lisp
+++ b/util/cycle-mru/package.lisp
@@ -1,4 +1,4 @@
 ;;;; package.lisp
 
 (defpackage #:cycle-mru
-  (:use #:cl))
+  (:use #:cl :stumpwm))

--- a/util/cycle-mru/package.lisp
+++ b/util/cycle-mru/package.lisp
@@ -1,4 +1,4 @@
 ;;;; package.lisp
 
 (defpackage #:cycle-mru
-  (:use #:cl :stumpwm))
+  (:use #:cl #:stumpwm))


### PR DESCRIPTION
Hi there,

I packaged up some code I found handy on the stumpwm-devel mailing list, and thought others could benefit/help make it better or extend it.

The module allows one to cycle a groups' windows in most recently used order - in a similar fashion to the default alt/command-tab mechanism of Windows/macOS.

I would very much appreciate any hints on how to extend the code to have a windowlist popup and only switch to the selected window on release of the keys.

Cheers,
Toby

**P.S. I've been trying to learn more lisp in the last week to make the aforementioned changes, and in the process came up with another package (for viewing sensor information in the modeline) which you'll see in the later commits in this pull request.  

I hope it's alright to include both in this one pull request. Please let me know if this is bad form and if I should split them up.**