### PR TITLE
notify: add newline between summary and body. Dunst-like

### DIFF
--- a/util/notify/notify.lisp
+++ b/util/notify/notify.lisp
@@ -22,7 +22,7 @@
 (defun show-notification (app icon summary body)
   "Show the notification using standard STUMPWM::MESSAGE function"
   (declare (ignore app icon))
-  (stumpwm:message "~A ~A" summary body))
+  (stumpwm:message "~A ~% ~A" summary body))
 
 (define-dbus-object notify-dbus-service
     (:path "/org/freedesktop/Notifications"))


### PR DESCRIPTION
Hi, 

Gnome Notifier and Dunst separates notifications Summary from its Body.

Ive just add a newline to do as much.

