### PR TITLE
Sort readme modules

### DIFF
--- a/README.org
+++ b/README.org
@@ -70,46 +70,46 @@ to the world!
   (click for its respective README/docs)
 # Don't edit anything below this line, the script will blow it away
 # --
-** Minor Modes
-- [[./minor-mode/mpd/README.org][mpd]] :: Displays information about the music player daemon (MPD).
-** Modeline
-- [[./minor-mode/notifications/README.org][notifications]] :: A notification library that sends notifications to the modeline via stumpish or from stumpwm itself.
-- [[./modeline/battery-portable/README.org][battery-portable]] :: Add battery information to the modeline in a portable way.
-- [[./modeline/net/README.org][net]] :: Displays information about the current network connection.
-- [[./modeline/disk/README.org][disk]] :: Display filesystem information in the modeline
-- [[./modeline/wifi/README.org][wifi]] :: Display information about your wifi.
-- [[./modeline/stumptray/README.org][stumptray]] :: System Tray for stumpwm.
-- [[./modeline/cpu/README.org][cpu]] :: Add cpu info to the modeline.
-- [[./modeline/maildir/README.org][maildir]] :: Display maildir information in the modeline (%M conflicts with mem).
-- [[./modeline/hostname/README.org][hostname]] :: Put hostname in the StumpWM modeline
-- [[./modeline/mem/README.org][mem]] :: Display memory in the modeline, %M conflicts with maildir.
 ** Media
 - [[./media/amixer/README.org][amixer]] :: Manipulate the volume using amixer
+** Minor Modes
+- [[./minor-mode/mpd/README.org][mpd]] :: Displays information about the music player daemon (MPD).
+- [[./minor-mode/notifications/README.org][notifications]] :: A notification library that sends notifications to the modeline via stumpish or from stumpwm itself.
+** Modeline
+- [[./modeline/battery-portable/README.org][battery-portable]] :: Add battery information to the modeline in a portable way.
+- [[./modeline/cpu/README.org][cpu]] :: Add cpu info to the modeline.
+- [[./modeline/disk/README.org][disk]] :: Display filesystem information in the modeline
+- [[./modeline/hostname/README.org][hostname]] :: Put hostname in the StumpWM modeline
+- [[./modeline/maildir/README.org][maildir]] :: Display maildir information in the modeline (%M conflicts with mem).
+- [[./modeline/mem/README.org][mem]] :: Display memory in the modeline, %M conflicts with maildir.
+- [[./modeline/net/README.org][net]] :: Displays information about the current network connection.
+- [[./modeline/stumptray/README.org][stumptray]] :: System Tray for stumpwm.
+- [[./modeline/wifi/README.org][wifi]] :: Display information about your wifi.
 ** Utilities
 - [[./util/alert-me/README.org][alert-me]] :: Alert me that an event is coming
-- [[./util/perwindowlayout/README.org][perwindowlayout]] :: Change the keyboard layout per window.
-- [[./util/command-history/README.org][command-history]] :: Save and load the stumpwm::*input-history* to a file
-- [[./util/pass/README.org][pass]] :: Integrate 'pass' with StumpWM
-- [[./util/swm-gaps/README.org][swm-gaps]] :: Pretty (useless) gaps for StumpWM
-- [[./util/ttf-fonts/README.org][ttf-fonts]] :: A pure lisp implementation of TTF font rendering.
-- [[./util/kbd-layouts/README.org][kbd-layouts]] :: Keyboard layout switcher for StumpWM
-- [[./util/globalwindows/README.org][globalwindows]] :: Manipulate all windows in the current X session
-- [[./util/clipboard-history/README.org][clipboard-history]] :: Simple clipboard history module for StumpWM
-- [[./util/windowtags/README.org][windowtags]] :: Add metadata to windows to manipulate them en mass.
-- [[./util/notify/README.org][notify]] :: DBus-based notification server part
-- [[./util/screenshot/README.org][screenshot]] :: Takes screenshots and stores them as png files
 - [[./util/app-menu/README.org][app-menu]] :: A simple application menu for launching shell commands
-- [[./util/undocumented/README.org][undocumented]] :: Look for stuff that should probably be in the manual that isn't
-- [[./util/winner-mode/README.org][winner-mode]] :: Emacs' winner-mode for StumpWM
-- [[./util/logitech-g15-keysyms/README.org][logitech-g15-keysyms]] :: Describe logitech-g15-keysyms here
-- [[./util/passwd/README.org][passwd]] :: A simple password utility based on ironclad.
-- [[./util/numpad-layouts/README.org][numpad-layouts]] :: A module for handling different keyboards numpad layouts
-- [[./util/searchengines/README.org][searchengines]] :: Allows searching text using prompt or clipboard contents with various search engines
-- [[./util/urgentwindows/README.org][urgentwindows]] :: Allows focusing application windows that need user attention
-- [[./util/pinentry/README.org][pinentry]] :: Integrate GnuPG Agent with StumpWM
-- [[./util/surfraw/README.org][surfraw]] :: Integrates surfraw with stumpwm.
+- [[./util/clipboard-history/README.org][clipboard-history]] :: Simple clipboard history module for StumpWM
+- [[./util/command-history/README.org][command-history]] :: Save and load the stumpwm::*input-history* to a file
+- [[./util/desktop-entry/README.org][desktop-entry]] :: desktop-entry
 - [[./util/end-session/README.org][end-session]] :: Provides commands to stumpwm that allow the user to shutdown, restart, and logoff through the stumpwm UI
-- [[./util/swm-emacs/README.org][swm-emacs]] :: A set of utilities for launching the beast.
+- [[./util/globalwindows/README.org][globalwindows]] :: Manipulate all windows in the current X session
+- [[./util/kbd-layouts/README.org][kbd-layouts]] :: Keyboard layout switcher for StumpWM
+- [[./util/logitech-g15-keysyms/README.org][logitech-g15-keysyms]] :: Describe logitech-g15-keysyms here
+- [[./util/notify/README.org][notify]] :: DBus-based notification server part
+- [[./util/numpad-layouts/README.org][numpad-layouts]] :: A module for handling different keyboards numpad layouts
+- [[./util/pass/README.org][pass]] :: Integrate 'pass' with StumpWM
+- [[./util/passwd/README.org][passwd]] :: A simple password utility based on ironclad.
+- [[./util/perwindowlayout/README.org][perwindowlayout]] :: Change the keyboard layout per window.
+- [[./util/pinentry/README.org][pinentry]] :: Integrate GnuPG Agent with StumpWM
 - [[./util/productivity/README.org][productivity]] :: Lock StumpWM down so you have to get work done.
 - [[./util/qubes/README.org][qubes]] :: Integration to Qubes OS (https://www.qubes-os.org)
-- [[./util/desktop-entry/README.org][desktop-entry]] :: desktop-entry
+- [[./util/screenshot/README.org][screenshot]] :: Takes screenshots and stores them as png files
+- [[./util/searchengines/README.org][searchengines]] :: Allows searching text using prompt or clipboard contents with various search engines
+- [[./util/surfraw/README.org][surfraw]] :: Integrates surfraw with stumpwm.
+- [[./util/swm-emacs/README.org][swm-emacs]] :: A set of utilities for launching the beast.
+- [[./util/swm-gaps/README.org][swm-gaps]] :: Pretty (useless) gaps for StumpWM
+- [[./util/ttf-fonts/README.org][ttf-fonts]] :: A pure lisp implementation of TTF font rendering.
+- [[./util/undocumented/README.org][undocumented]] :: Look for stuff that should probably be in the manual that isn't
+- [[./util/urgentwindows/README.org][urgentwindows]] :: Allows focusing application windows that need user attention
+- [[./util/windowtags/README.org][windowtags]] :: Add metadata to windows to manipulate them en mass.
+- [[./util/winner-mode/README.org][winner-mode]] :: Emacs' winner-mode for StumpWM

--- a/update-readme.sh
+++ b/update-readme.sh
@@ -2,9 +2,9 @@
 
 sed '/# --/q' README.org > tmpReadme
 
-for f in $(find . -name "*.asd"); 
-do 
-    desc=$(grep description $f | grep -o \".*\" | sed 's,",,g'); 
+for f in $(find . -name "*.asd");
+do
+    desc=$(grep description $f | grep -o \".*\" | sed 's,",,g');
     echo - [[$(dirname $f)/README.org][$(basename $f .asd)]] :: $desc >> tmpReadme
 done
 awk '/util/ && !x {print "** Utilities"; x=1} 1' tmpReadme > tmp; mv tmp tmpReadme

--- a/update-readme.sh
+++ b/update-readme.sh
@@ -7,8 +7,8 @@ do
     desc=$(grep description $f | grep -o \".*\" | sed 's,",,g');
     echo - [[$(dirname $f)/README.org][$(basename $f .asd)]] :: $desc >> tmpReadme
 done
-awk '/util/ && !x {print "** Utilities"; x=1} 1' tmpReadme > tmp; mv tmp tmpReadme
-awk '/media/ && !x {print "** Media"; x=1} 1' tmpReadme > tmp; mv tmp tmpReadme
-awk '/minor-mode/ && !x {print "** Minor Modes"; x=1} 1' tmpReadme > tmp; mv tmp tmpReadme
-awk '/modeline/ && !x {print "** Modeline"; x=1} 1' tmpReadme > tmp; mv tmp tmpReadme
+awk '/\/util\// && !x {print "** Utilities"; x=1} 1' tmpReadme > tmp; mv tmp tmpReadme
+awk '/\/media\// && !x {print "** Media"; x=1} 1' tmpReadme > tmp; mv tmp tmpReadme
+awk '/\/minor-mode\// && !x {print "** Minor Modes"; x=1} 1' tmpReadme > tmp; mv tmp tmpReadme
+awk '/\/modeline\// && !x {print "** Modeline"; x=1} 1' tmpReadme > tmp; mv tmp tmpReadme
 mv tmpReadme README.org

--- a/update-readme.sh
+++ b/update-readme.sh
@@ -2,7 +2,7 @@
 
 sed '/# --/q' README.org > tmpReadme
 
-for f in $(find . -name "*.asd");
+for f in $(find . -name "*.asd" | sort);
 do
     desc=$(grep description $f | grep -o \".*\" | sed 's,",,g');
     echo - [[$(dirname $f)/README.org][$(basename $f .asd)]] :: $desc >> tmpReadme


### PR DESCRIPTION
This just cleans up a couple annoyances in the README-generation script:

1. Modules are sorted by name
2. When categorizing modules, be sure to match a directory (e.g. `/\/modeline\//` instead of `/modeline/`) just in case that keyword appears in a description.  The `minor-mode/notifications` module was being grouped in with `modeline` because it contains "modeline" in its description.