### PR TITLE
[golden-ratio] Prevent automatic resizing of single frame in head

### DIFF
--- a/util/golden-ratio/swm-golden-ratio.lisp
+++ b/util/golden-ratio/swm-golden-ratio.lisp
@@ -18,10 +18,10 @@
                                            (stumpwm:current-head)))))
 
 (defun resize-to-golden-ratio (to-frame from-frame)
-  (if *golden-ratio-on*
-      (let* ((target-x (target-px (stumpwm::head-width (stumpwm:current-head))))
-             (target-y (target-px (stumpwm::head-height (stumpwm:current-head)))))
-        (if *golden-ratio-on*
+  (if (not (stumpwm::single-frame-p))
+      (if *golden-ratio-on*
+          (let* ((target-x (target-px (stumpwm::head-width (stumpwm:current-head))))
+                 (target-y (target-px (stumpwm::head-height (stumpwm:current-head)))))
             (progn (setq *golden-ratio-on* nil)
                    (balance-current-group)
                    (stumpwm:resize (resize-px target-x

--- a/util/golden-ratio/swm-golden-ratio.lisp
+++ b/util/golden-ratio/swm-golden-ratio.lisp
@@ -18,17 +18,16 @@
                                            (stumpwm:current-head)))))
 
 (defun resize-to-golden-ratio (to-frame from-frame)
-  (if (not (stumpwm::single-frame-p))
-      (if *golden-ratio-on*
-          (let* ((target-x (target-px (stumpwm::head-width (stumpwm:current-head))))
-                 (target-y (target-px (stumpwm::head-height (stumpwm:current-head)))))
-            (progn (setq *golden-ratio-on* nil)
-                   (balance-current-group)
-                   (stumpwm:resize (resize-px target-x
-                                              (stumpwm::frame-width to-frame))
-                                   (resize-px target-y
-                                              (stumpwm::frame-height to-frame)))
-                   (setq *golden-ratio-on* T))))))
+  (when (and *golden-ratio-on* (not (stumpwm::single-frame-p))
+             (let* ((target-x (target-px (stumpwm::head-width (stumpwm:current-head))))
+                    (target-y (target-px (stumpwm::head-height (stumpwm:current-head)))))
+               (setq *golden-ratio-on* nil)
+               (balance-current-group)
+               (stumpwm:resize (resize-px target-x
+                                          (stumpwm::frame-width to-frame))
+                               (resize-px target-y
+                                          (stumpwm::frame-height to-frame)))
+               (setq *golden-ratio-on* T)))))
 
 (stumpwm:defcommand toggle-golden-ratio () ()
   "Toggle golden ratio"


### PR DESCRIPTION
When working with multiple monitors, golden-ratio-mode would crash when trying
to balance a head with only one frame inside of it. This would happen when trying to move from one screen to another.

This fixes make sure that there is more than one frame before trying to resize the newly focused frame.