### PR TITLE
Disk usage use lisp lib

### DIFF
--- a/modeline/disk/README.org
+++ b/modeline/disk/README.org
@@ -1,19 +1,32 @@
+* Intro
+
+This module prints some information about your disks on the modeline.
+
+* Dependency
+
+Put:
+#+BEGIN_SRC common-lisp
+    (ql:quickload "cl-diskspace")
+#+END_SRC
+
 ** Usage
 
 Put:
-#+BEGIN_SRC 
+#+BEGIN_SRC
     (load-module "disk")
 #+END_SRC
 
-into your =~/.stumpwmrc=
+into your ~~/.stumpwmrc~
 
 Then you can use "%D" in your mode line format.
 
-Filesystem(s) to be displayed can be customized by modifying the *disk-usage-paths* list.
+Filesystem(s)  to be  displayed  can be  customized  by modifying  the
+~*disk-usage-paths*~ list.
 
-You can customize the modeline format (*disk-modeline-fmt*). 
+You can customize the modeline format (~*disk-modeline-fmt*~).
 
-The default value for displaying disk usage information on the modeline.
+The  default  value  for  displaying disk  usage  information  on  the
+modeline.
 
 |------+----------------------------------|
 | Code | Result                           |
@@ -26,3 +39,8 @@ The default value for displaying disk usage information on the modeline.
 | %p   | Filesystem used space in percent |
 | %m   | Filesystem mount point           |
 |------+----------------------------------|
+
+** Known issues
+
+This module will  fallback on an external shell process  method to get
+informations if either ~%m~ or ~%d~ is used.

--- a/modeline/disk/disk.asd
+++ b/modeline/disk/disk.asd
@@ -5,7 +5,7 @@
   :description "Display filesystem information in the modeline"
   :author "Morgan Veyret"
   :license "GPLv3"
-  :depends-on (#:stumpwm)
+  :depends-on (:stumpwm
+               :cl-diskspace)
   :components ((:file "package")
                (:file "disk")))
-

--- a/modeline/disk/disk.lisp
+++ b/modeline/disk/disk.lisp
@@ -39,7 +39,7 @@
     (#\p  disk-get-use-percent)
     (#\m  disk-get-mount-point)))
 
-(defparameter *disk-modeline-fmt* "dev %m mount %d av: %a per %p %u/%s"
+(defparameter *disk-modeline-fmt* "%m: %u/%s"
   "The default value for displaying disk usage information on the modeline.
 
 @table @asis

--- a/modeline/disk/package.lisp
+++ b/modeline/disk/package.lisp
@@ -1,8 +1,8 @@
 ;;;; package.lisp
 
-(defpackage #:disk
-  (:use #:cl :stumpwm)
+(defpackage :disk
+  (:use :cl
+        :stumpwm)
   (:export
-   #:*disk-modeline-fmt*
-   #:*disk-usage-paths*))
-
+   :*disk-modeline-fmt*
+   :*disk-usage-paths*))


### PR DESCRIPTION
Hi!

I tried to address #125, there are some issues with this approach:

- the size (available,  total etc.) shows the decimals  (this could be
probably better be fixed by the cl-diskspace library);

- to shows the mountpoint or the  device the old method (shell process
  must be used);

- of course a new dependency is added.