### PR TITLE
Bugfix: Add completions string (the empty string).

### DIFF
--- a/util/pinentry/pinentry.lisp
+++ b/util/pinentry/pinentry.lisp
@@ -8,6 +8,7 @@
         (prompt (read-line stream)))
     (format stream (or (stumpwm:read-one-line (stumpwm:current-screen)
                                               (format nil "~a~%~a " description prompt)
+                                              ""
                                               :password t)
                        ""))))
 


### PR DESCRIPTION
Previously the arity was wrong, so this did not work at all. Now it does work.