### PR TITLE
Update maximize-window override in swm-gaps to reflect recent changes in master

### DIFF
--- a/util/swm-gaps/README.org
+++ b/util/swm-gaps/README.org
@@ -10,7 +10,7 @@ Credit goes to the original author.
 #+BEGIN_QUOTE
 This modifies StumpWM's internal functions ~maximize-window~ and ~neighbour~, so
 might not work as expected if those definitions change in the core. Currently
-works with ~v1.0.1-rc~.
+works with ~v19.11~.
 #+END_QUOTE
 
 #+BEGIN_SRC common-lisp

--- a/util/swm-gaps/swm-gaps.lisp
+++ b/util/swm-gaps/swm-gaps.lisp
@@ -86,8 +86,9 @@ HEIGHT are subtracted."
                                                                   oh))))
         ;; update the "extents"
         (xlib:change-property (window-xwin win) :_NET_FRAME_EXTENTS
-                              (list wx wy
+                              (list wx
                                     (- (xlib:drawable-width (window-parent win)) width wx)
+                                    wy
                                     (- (xlib:drawable-height (window-parent win)) height wy))
                               :cardinal 32))
       (update-configuration win))))


### PR DESCRIPTION
A recent fix to an issue in stumpwm master (see [this commit](https://github.com/stumpwm/stumpwm/commit/072836f261db2dc2b61ec91e4b43451e6a72d0ab)) was partially getting reverted by the function redefinition that happens in swm-gaps module. This commit updates swm-gaps to reflect those changes.