### PR TITLE
Deport list-undocumented (should be NIL) from :undocumented

### DIFF
--- a/util/undocumented/package.lisp
+++ b/util/undocumented/package.lisp
@@ -1,5 +1,5 @@
 ;;;; package.lisp
 
 (defpackage #:undocumented
-  (:use #:cl :stumpwm))
-
+  (:use #:cl :stumpwm)
+  (:export :list-undocumented))


### PR DESCRIPTION
This deports this symbol, which is the only one in the package.