### PR TITLE
Fix pinentry too many keyword arguments

### DIFF
--- a/util/pinentry/pinentry.lisp
+++ b/util/pinentry/pinentry.lisp
@@ -8,7 +8,6 @@
         (prompt (read-line stream)))
     (format stream (or (stumpwm:read-one-line (stumpwm:current-screen)
                                               (format nil "~a~%~a " description prompt)
-                                              ""
                                               :password t)
                        ""))))
 


### PR DESCRIPTION
This single line breaks it, since `initial-input` is a keyword argument (not a `&optional`).