### PR TITLE
Disk usage use lisp lib, trap condition

### DIFF
--- a/modeline/disk/disk.lisp
+++ b/modeline/disk/disk.lisp
@@ -114,14 +114,20 @@ Filesystem type
     (format nil "~a%" value)))
 
 (defun disk-get-device (path)
-  #+linux (cl-mount-info:mountpoint->device path)
+  #+linux
+  (handler-case
+      (cl-mount-info:mountpoint->device path)
+    (error () "ERR"))
   #-linux (disk-usage-get-field path 0))
 
 (defun disk-get-mount-point (path)
   path)
 
 (defun disk-get-filesystem-type (path)
-  #+linux (cl-mount-info:mountpoint->fstype path)
+  #+linux
+  (handler-case
+      (cl-mount-info:mountpoint->fstype path)
+    (error () "ERR"))
   #-linux "filesystem type supported only on GNU/Linux :-(")
 
 (defun use-fallback-method-p ()


### PR DESCRIPTION
 - trapped cl-mount-info' conditions

  If,  for  some  reasons,  the  file  containing  mount  information
  (default "/etc/mtab")  can not be  opened, capture the  condition and
  prevent stumpwm to crash.

PS: sorry for the mess with commits :(