### PR TITLE
Add timeout, fix "<character> is not bound" bug

### DIFF
--- a/util/pinentry/pinentry.lisp
+++ b/util/pinentry/pinentry.lisp
@@ -5,12 +5,17 @@
 
 (defun main (stream)
   (let ((description (percent:decode (read-line stream)))
-        (prompt (read-line stream)))
-    (format stream (or (stumpwm:read-one-line (stumpwm:current-screen)
-                                              (format nil "~a~%~a " description prompt)
-                                              :password t)
-                       ""))))
-
-(usocket:socket-server "127.0.0.1" 22222 #'main nil
-                       :in-new-thread t
-                       :multi-threading t)
+        (prompt (read-line stream))
+        (timeout (read-line stream)))
+    (handler-case
+        (usocket:socket-server "127.0.0.1" 22222 #'main nil
+                               :in-new-thread t
+                               :multi-threading t
+                               :timeout timeout)
+      (address-in-use-error (c) (declare (ignore c)))
+      (:no-error (c)
+        (declare (ignore c))
+        (format stream (or (stumpwm:read-one-line (stumpwm:current-screen)
+                                                           (format nil "~a~%~a " description prompt)
+                                                           :password t)
+                                    ""))))))

--- a/util/pinentry/stumpwm-pinentry
+++ b/util/pinentry/stumpwm-pinentry
@@ -9,6 +9,8 @@ while IFS="\n" read -r command; do
         description=${command:8}
     elif [[ "$command" == SETPROMPT* ]]; then
         prompt=${command:10}
+    elif [[ "$command" == SETTIMEOUT* ]]; then
+        timeout=${command:10}
     elif [ "$command" == GETPIN ]; then
         password=$(printf "%s\n%s\n" "$description" "$prompt" | nc 127.0.0.1 22222)
         echo D "$password"


### PR DESCRIPTION
Implement pinentry's SETTIMEOUT command so there is enough time to enter a long
message. The bug rendered StumpWM unusable when entering a password too slowly for the timeout.

To do this I had to move the starting of the server to inside the `main`, which means the server is not opened until pinentry is called (an improvement!).