### PR TITLE
Fix notify plugin compilation

### DIFF
--- a/util/notify/notify.lisp
+++ b/util/notify/notify.lisp
@@ -46,9 +46,9 @@
   (let ((lines (split-sequence:split-sequence #\newline body)))
     (format nil "~{~A~^~%~}"
             (multiple-value-bind (fst rst)
-                (stumpwm:take max-lines
-                              (flatten-once
-                               (mapcar #'rewrap-line lines)))
+                (stumpwm::take max-lines
+                               (flatten-once
+                                (mapcar #'rewrap-line lines)))
               (if (and rst show-ellipsis)
                   (append fst (list "..."))
                   fst)))))


### PR DESCRIPTION
SBCL complains because ```take``` is not an exported symbol of the stumpwm package.
