### PR TITLE
Better battery info

### DIFF
--- a/modeline/battery-portable/battery-portable.lisp
+++ b/modeline/battery-portable/battery-portable.lisp
@@ -297,13 +297,13 @@
                                         (return-from battery-info-string
                                           "(not implemented)")))))
       (if (endp batteries)
-          (format fmt "(no battery)")
+          (format fmt "(no procfs battery)")
           (loop
              for bat in batteries
              do (multiple-value-bind (state perc time)
                     (state-of bat)
                   (ecase state
-                    (:unknown (format fmt "(no info)"))
+                    (:unknown (format fmt "(no sysfs battery)"))
                     (:charged (format fmt "~~ ~D%" (round perc)))
                     ((:charging :discharging)
                      (format fmt "~/battery-portable::fmt-time/~A ^[~A~D%^]"


### PR DESCRIPTION
Improve no battery information mode line message

Makes it easier to see that \*prefer-sysfs\* should be set if the current value is
not working.