### PR TITLE
Try sysfs and procfs before giving up battery mode line

### DIFF
--- a/modeline/battery-portable/README.org
+++ b/modeline/battery-portable/README.org
@@ -6,10 +6,3 @@ To load this module, place
 
 in your =.stumpwmrc=. Battery information is then available via %B
 in your mode-line config.
-
-If you have an older kernel and the above doesn't work, add
-#+BEGIN_SRC lisp
-    (setf stumpwm.contrib.battery-portable:*prefer-sysfs* nil)
-#+END_SRC
-below the above line.
-


### PR DESCRIPTION
Remove the need for `*prefer-sysfs*` since it tries both and uses the same format.

Removes the need for the user to set that, so it is removed from the readme.