### PR TITLE
Change default gaps behavior, no gaps for fullscreen windows.

### DIFF
--- a/util/swm-gaps/swm-gaps.lisp
+++ b/util/swm-gaps/swm-gaps.lisp
@@ -11,7 +11,7 @@
 
 (defun apply-gaps-p (win)
   "Tell if gaps should be applied to this window"
-  (and *gaps-on* (not (stumpwm::window-transient-p win))))
+  (and *gaps-on* (not (stumpwm::window-transient-p win)) (not (window-fullscreen win))))
 
 (defun window-edging-p (win direction)
   "Tell if the window is touching the head in the given direction."


### PR DESCRIPTION
I think that by default, SWM-GAPS shouldn't apply gaps to fullscreen windows.

If this shouldn't be, maybe I should add a `*apply-gaps-fullscreen-windows*` or something of the like to toggle this behavior.