### PR TITLE
Do not display 0:00 time

### DIFF
--- a/modeline/battery-portable/battery-portable.lisp
+++ b/modeline/battery-portable/battery-portable.lisp
@@ -293,7 +293,8 @@
 
 (defun fmt-time (stream arg colonp atp)
   (declare (ignore colonp atp))
-  (when (numberp arg)
+  (when (and (numberp arg)
+             (plusp arg))
     (multiple-value-bind (hours rest)
         (truncate arg 3600)
       (format stream "~D:~2,'0D" hours (floor rest 60)))))


### PR DESCRIPTION
No longer displays a mode line like this:

0:00+ 87%

On machines that always show 0:00 due to lack of support. Since it isn't helpful
for a running computer to show 0 time left on the battery, it is better to
remove this.

The new display is minimally changed for such machines:

\+ 87%