### PR TITLE
Add $PASSWORD_STORE_DIR support to pass for XDG

### DIFF
--- a/util/pass/pass.asd
+++ b/util/pass/pass.asd
@@ -3,5 +3,5 @@
     :description "Integrate 'pass' with StumpWM"
     :author "Florian Margaine <florian@margaine.com>"
     :license "GPLv3"
-    :depends-on (:stumpwm)
+    :depends-on (:stumpwm :uiop)
     :components ((:file "pass")))

--- a/util/pass/pass.lisp
+++ b/util/pass/pass.lisp
@@ -1,7 +1,7 @@
 (defpackage #:pass
   (:use #:cl)
-  (:export *password-store*)
-  (:import-from :uiop :getenv-absolute-directory))
+  (:export #:*password-store*)
+  (:import-from #:uiop #:getenv-absolute-directory))
 
 (in-package #:pass)
 

--- a/util/pass/pass.lisp
+++ b/util/pass/pass.lisp
@@ -6,9 +6,7 @@
 (in-package #:pass)
 
 (defvar *password-store*
-  ;; pass has partial support for XDG Base Dirs using export PASSWORD_STORE_DIR.
   (or (getenv-absolute-directory "PASSWORD_STORE_DIR")
-      ;; Default is in the home directory.
       (merge-pathnames #p".password-store/"
                        (user-homedir-pathname)))
   "Location to search for names in the password store, according to the XDG Base

--- a/util/pass/pass.lisp
+++ b/util/pass/pass.lisp
@@ -12,7 +12,7 @@
       (merge-pathnames #p".password-store/"
                        (user-homedir-pathname)))
   "Location to search for names in the password store, according to the XDG Base
-Directory Specification. Tries PASSWORD_STORE_DIR then $HOME/.password-store/.")
+Directory Specification. Tries $PASSWORD_STORE_DIR then $HOME/.password-store/.")
 
 (defun pass-entries ()
   (let ((home-ns-len (length (namestring *password-store*))))

--- a/util/pass/pass.lisp
+++ b/util/pass/pass.lisp
@@ -1,10 +1,18 @@
 (defpackage #:pass
   (:use #:cl)
-  (:export *password-store*))
+  (:export *password-store*)
+  (:import-from :uiop :getenv-absolute-directory))
 
 (in-package #:pass)
 
-(defvar *password-store* (merge-pathnames #p".password-store/" (user-homedir-pathname)))
+(defvar *password-store*
+  ;; pass has partial support for XDG Base Dirs using export PASSWORD_STORE_DIR.
+  (or (getenv-absolute-directory "PASSWORD_STORE_DIR")
+      ;; Default is in the home directory.
+      (merge-pathnames #p".password-store/"
+                       (user-homedir-pathname)))
+  "Location to search for names in the password store, according to the XDG Base
+Directory Specification. Tries PASSWORD_STORE_DIR then $HOME/.password-store/.")
 
 (defun pass-entries ()
   (let ((home-ns-len (length (namestring *password-store*))))


### PR DESCRIPTION
pass has partial support for the XDG Base Directory specification. The most
common value for `$PASSWORD_STORE_DIR` is either unset or
`$XDG_DATA_DIR/password-store`

See man pass for details of this variable