### PR TITLE
mpd: replace deprecated functions

### DIFF
--- a/minor-mode/mpd/mpd.lisp
+++ b/minor-mode/mpd/mpd.lisp
@@ -470,7 +470,7 @@ Volume
       (t (values choice selection)))))
 
 (defun mpd-selected-item (menu)
-  (nth (menu-state-selected menu) (menu-state-table menu)))
+  (nth (stumpwm::menu-selected menu) (stumpwm::menu-table menu)))
 
 (defun mpd-menu-action (action-type)
   (lambda (menu)


### PR DESCRIPTION
As of commit 4c207ec1ad12ed6208c7e98ef4ed40db04efe4ba, functions menu-state-selected and menu-state-table are deprecated.

This commit reintroduces the capability to open the playlist menu.