### PR TITLE
BUGFIX: Trying to run any command defined in `amixer` failes.

### DIFF
--- a/media/amixer/amixer.asd
+++ b/media/amixer/amixer.asd
@@ -5,7 +5,7 @@
   :description "Manipulate the volume using amixer"
   :author "Amy Templeton, Jonathan Moore Liles, Ivy Foster"
   :license "GPL v3"
-  :depends-on (#:stumpwm)
+  :depends-on (#:stumpwm #:alexandria)
   :components ((:file "package")
                (:file "amixer")))
 

--- a/media/amixer/amixer.lisp
+++ b/media/amixer/amixer.lisp
@@ -9,12 +9,12 @@
 ;;; Maintainer: Ivy Foster
 ;;;
 ;;; Code:
-(defvar *default-device* "default")
+(defvar *default-device* 0)
 
 (defun volcontrol (device channel amount)
   (let* ((output (run-shell-command
-                  (concat "amixer -D "
-                          (or device *default-device*)
+                  (concat "amixer -c "
+                          (write-to-string (or device *default-device*))
                           " sset "
                           channel
                           " "

--- a/media/amixer/package.lisp
+++ b/media/amixer/package.lisp
@@ -2,6 +2,7 @@
 
 (defpackage #:amixer
   (:use #:cl :stumpwm)
+  (:import-from :alexandria :with-gensyms)
   (:export
    #:*default-device*))
 


### PR DESCRIPTION
BUGFIX: Trying to run any command defined in `amixer` failes.
# Reproduction
  Run `(amixer:amixer-Front-toggle)`, which should toggle a front speaker.

# Result

```common-lisp
; The value
;   NIL
; is not of type
;   VECTOR
;    [Condition of type TYPE-ERROR]
;
; Backtrace:
    (AMIXER::VOLCONTROL NIL "Front" "toggle")
    (AMIXER:AMIXER-FRONT-TOGGLE NIL)
```

To fix this bug, amixer has been moved to using the `-c` argument instead of
`-D`. StumpWM also has a breaking change to `run-shell-command`.
