### PR TITLE
mpd: fix choice in playlist

### DIFF
--- a/minor-mode/mpd/mpd.lisp
+++ b/minor-mode/mpd/mpd.lisp
@@ -514,7 +514,7 @@ Volume
                       (if (equal (assoc-value :state status) "play")
                           (parse-integer (assoc-value :song status))
                           0)))
-      (let ((song-number (position choice options)))
+      (let ((song-number (position (car choice) options)))
         (case action
           (:mpd-playlist-move-up
            (if (= song-number 1)
@@ -523,9 +523,9 @@ Volume
                       (mpd-browse-playlist (1- song-number)))))
           (:mpd-playlist-move-down
            (if (= song-number (length options))
-             (mpd-browse-playlist song-number)
-             (progn (mpd-swap-tracks song-number (1+ song-number))
-                    (mpd-browse-playlist (1+ song-number)))))
+               (mpd-browse-playlist song-number)
+               (progn (mpd-swap-tracks song-number (1+ song-number))
+                      (mpd-browse-playlist (1+ song-number)))))
           (:mpd-playlist-delete
            (when song-number
              (mpd-remove-track song-number)


### PR DESCRIPTION
After updating and building both stumpwm and stumpwm-contrib from latest commits (in OpenBSD -current), mpd-browse-playlist fails.

Commit below seems to address this issue. Comments/criticism welcome, as I'm new to common lisp.

choice → (car choice) to use in position.