### PR TITLE
unifiy -c and -D options for amixer

### DIFF
--- a/media/amixer/amixer.lisp
+++ b/media/amixer/amixer.lisp
@@ -9,12 +9,25 @@
 ;;; Maintainer: Ivy Foster
 ;;;
 ;;; Code:
-(defvar *default-device* "default")
+(defvar *default-device* "default"
+  "default audio device to control by amixer, string, number, or null.
+If it is a string, it will be used as a device name as it is,
+if it is a number it will be translated to the string \"hw:0\",
+if NIL don't send any device at all.")
+
+(defun translate-device-to-option (device)
+  "see docstring of *DEFAULT-DEVICE*"
+  (etypecase device
+    (string (format nil "-D ~a " device))
+    (number (format nil "-D hw:~d " device))
+    (null (if *default-device*
+              (translate-device-to-option *default-device*)
+              ""))))
 
 (defun volcontrol (device channel amount)
   (let* ((output (run-shell-command
-                  (concat "amixer -D "
-                          (or device *default-device*)
+                  (concat "amixer "
+                          (translate-device-to-option device)
                           " sset "
                           channel
                           " "


### PR DESCRIPTION
Some want to use device numbers with `-c` others want device names with `-D` this PR unifies both options.

see discussion https://github.com/stumpwm/stumpwm-contrib/pull/187


I don't know where to put tests, I tested with:
```
(list (let ((*default-device* "default"))
        (list (string= (translate-device-to-option nil) "-D default ")
             (string= (translate-device-to-option 1) "-D hw:1 ")
             (string= (translate-device-to-option "my-device") "-D my-device ")))
      (let ((*default-device* 0))
        (list (string= (translate-device-to-option nil) "-D hw:0 ")
              (string= (translate-device-to-option 1) "-D hw:1 ")
              (string= (translate-device-to-option "my-device") "-D my-device ")))
      (let ((*default-device* nil))
        (list (string= (translate-device-to-option nil) "")
              (string= (translate-device-to-option 1) "-D hw:1 ")
              (string= (translate-device-to-option "my-device") "-D my-device "))))
```