### PR TITLE
Unify amixer device options for stump volume control

### DIFF
--- a/media/stump-volume-control/README
+++ b/media/stump-volume-control/README
@@ -44,6 +44,16 @@ any specific sound card explicitly:
 
   (setf stump-volume-control:*sound-card* nil)
 
+Or you can set it to a device name, for example "default":
+
+  (setf stump-volume-control:*sound-card* "default")
+
+Note, internally device numbers are translated to the device name
+of pattern "hw:<number>", so these two calls have the same effect:
+
+  (setf stump-volume-control:*sound-card* 1)
+  (setf stump-volume-control:*sound-card* "hw:1)
+
 
 PulseAudio compatibility
 ------------------------

--- a/media/stump-volume-control/README
+++ b/media/stump-volume-control/README
@@ -52,7 +52,7 @@ Note, internally device numbers are translated to the device name
 of pattern "hw:<number>", so these two calls have the same effect:
 
   (setf stump-volume-control:*sound-card* 1)
-  (setf stump-volume-control:*sound-card* "hw:1)
+  (setf stump-volume-control:*sound-card* "hw:1")
 
 
 PulseAudio compatibility


### PR DESCRIPTION
This is the behavior I have proposed for the amixer module in #194