### PR TITLE
add option :leave-alone for *caps-lock-behavior* to not send any CapsLock option at all

### DIFF
--- a/util/kbd-layouts/README.org
+++ b/util/kbd-layouts/README.org
@@ -18,6 +18,6 @@ variable =*CAPS-LOCK-BEHAVIOR*=. Available are the following values:
 - =:normal= - CapsLock serves as CapsLock
 - =:ctrl= - CapsLock serves as additional Ctrl
 - =:swapped= - CapsLock and Ctrl are swapped
+- =:leave-alone= - do not change CapsLock with setxkbmap
 By default the command =SWITCH-KEYBOARD-LAYOUT= is bound to the key
 combination =s-SPC= (=WinKey-Space=).
-

--- a/util/kbd-layouts/README.org
+++ b/util/kbd-layouts/README.org
@@ -13,11 +13,21 @@ those used by setxkbmap, e.g.:
 #+begin_src lisp
 (keyboard-layout-list "us" "pl" "ru -variant phonetic")
 #+end_src
+This will also immediately select first layout from the list.
+
 You can also specify the behavior of the CapsLock key using
 variable =*CAPS-LOCK-BEHAVIOR*=. Available are the following values:
 - =:normal= - CapsLock serves as CapsLock
 - =:ctrl= - CapsLock serves as additional Ctrl
 - =:swapped= - CapsLock and Ctrl are swapped
 - =:leave-alone= - do not change CapsLock with setxkbmap
+Add for example:
+#+begin_src lisp
+(setf kbd-layouts:*caps-lock-behavior* :leave-alone)
+#+end_src
+Note: If you do change =*CAPS-LOCK-BEHAVIOR*= add the call before
+the call to =KEYBOARD-LAYOUT-LIST= in your config file, to have it
+affect the initial configuration of your keyboard.
+
 By default the command =SWITCH-KEYBOARD-LAYOUT= is bound to the key
 combination =s-SPC= (=WinKey-Space=).

--- a/util/kbd-layouts/kbd-layouts.lisp
+++ b/util/kbd-layouts/kbd-layouts.lisp
@@ -6,14 +6,14 @@
 ;; Variables ;;
 ;;;;;;;;;;;;;;;
 
-(defvar *available-keyboard-layouts* nil)
+(defvar *available-keyboard-layouts* '#1=("us" . #1#))
 
 ;; Available options:
 ;; :normal      -> CapsLock
 ;; :ctrl        -> Ctrl
 ;; :swapped     -> Swap Ctrl and CapsLock
 ;; :leave-alone -> do not change CapsLock
-(defvar *caps-lock-behavior* nil)
+(defvar *caps-lock-behavior* :normal)
 
 ;; Custom option string appended to setxkbmap
 (defvar *custom-setxkb-options* nil)
@@ -64,9 +64,5 @@
 ;;;;;;;;;;;;;;
 ;; Defaults ;;
 ;;;;;;;;;;;;;;
-
-(setf *caps-lock-behavior* :normal)
-
-(keyboard-layout-list "us")
 
 (define-key *top-map* (kbd "s-SPC") "switch-keyboard-layout")

--- a/util/kbd-layouts/kbd-layouts.lisp
+++ b/util/kbd-layouts/kbd-layouts.lisp
@@ -9,9 +9,10 @@
 (defvar *available-keyboard-layouts* nil)
 
 ;; Available options:
-;; :normal -> CapsLock
-;; :ctrl   -> Ctrl
-;; :swapped-> Swap Ctrl and CapsLock
+;; :normal      -> CapsLock
+;; :ctrl        -> Ctrl
+;; :swapped     -> Swap Ctrl and CapsLock
+;; :leave-alone -> do not change CapsLock
 (defvar *caps-lock-behavior* nil)
 
 ;; Custom option string appended to setxkbmap
@@ -52,8 +53,9 @@
                    *caps-lock-behavior*
                  (:normal "caps:capslock")
                  (:ctrl "ctrl:nocaps")
-                 (:swapped "ctrl:swapcaps")))
-         (cmd (format nil "setxkbmap ~a -option ~a~@[ ~a~]" layout caps *custom-setxkb-options*)))
+                 (:swapped "ctrl:swapcaps")
+                 (:leave-alone nil)))
+         (cmd (format nil "setxkbmap ~a~@[ -option ~a~]~@[ ~a~]" layout caps *custom-setxkb-options*)))
     (run-shell-command cmd nil)
     (when *run-xmodmap*
       (run-shell-command "xmodmap ~/.Xmodmap"))


### PR DESCRIPTION
reason:
I configure caps lock with xmodmap in a personal fashion.
This PR allows to set the kbd-layouts:*caps-lock-behavior* to :leave-alone
which will mak kbd-layouts to not change the caps lock configuration at all
with setxkbmap, which just caused trouble in my case.

general remark:
I also do not see any reason why kbd-layout should try to mess with the setting by default.