### PR TITLE
New module "beckon" to fetch the mouse to the current window

### DIFF
--- a/util/beckon/README.org
+++ b/util/beckon/README.org
@@ -1,0 +1,29 @@
+#+title: beckon -- bring the mouse here
+#+author: Mark Dawson
+#+email: markgdawson@gmail.com
+
+* Purpose
+- Summon the mouse to the current window
+* Dependency
+None
+
+* Config
+- Use this in your StumpWM init file:
+#+begin_src common-lisp
+(load-module "beckon")
+#+end_src
+
+- Bind `beckon` to a key.
+#+begin_src lisp
+(define-key *root-map* (kbd "B") "beckon")
+#+end_src
+
+- Optionally set fractional position in current window
+  (default: 0.5 for both).
+#+begin_src lisp
+(setf *window-height-fraction* 0.5)
+(setf *window-width-fraction* 0.5)
+#+end_src
+
+* License
+GNU GPL v3

--- a/util/beckon/beckon.asd
+++ b/util/beckon/beckon.asd
@@ -1,0 +1,9 @@
+(asdf:defsystem #:beckon
+  :description "Beckon the mouse to the current window"
+  :author "Mark Dawson <markgdawson@gmail.com>"
+  :license  "GNU GPL v3"
+  :version "0.0.1"
+  :serial t
+  :components ((:file "package")
+               (:file "beckon"))
+  :depends-on (#:stumpwm))

--- a/util/beckon/beckon.lisp
+++ b/util/beckon/beckon.lisp
@@ -1,0 +1,20 @@
+(in-package #:beckon)
+
+(defvar *window-height-fraction* 0.5
+  "height from the top of the frame")
+
+(defvar *window-width-fraction* 0.5
+  "width from the top of the frame")
+
+(defcommand beckon () ()
+  "Beckon the mouse to the current window"
+  (with-accessors ((x frame-x)
+                   (y frame-y)
+                   (height frame-height)
+                   (width frame-width))
+      (window-frame (current-window))
+    (ratwarp
+     (round
+      (+ x (* width *window-height-fraction*)))
+     (round
+      (+ y (* height *window-width-fraction*))))))

--- a/util/beckon/package.lisp
+++ b/util/beckon/package.lisp
@@ -1,0 +1,4 @@
+(defpackage #:beckon
+  (:use #:cl)
+  (:import-from #:stumpwm #:defcommand #:window-frame #:ratwarp #:current-window #:frame-x #:frame-y #:frame-height #:frame-width)
+  (:export #:beckon #:*window-height-fraction* #:*window-width-fractionn*))


### PR DESCRIPTION
Minimal contrib to beckon the mouse to the middle of current-window.

This is useful in conjunction with banish, or for multi monitor setups when you suddenly need the mouse (for those stubborn applications that still insist clickable interfaces).

I named it "beckon" with the intention of being able to bind `C-t b` to banish and `C-t B` to beckon (or vice versa).

Comments on the code or suggestions very welcome.