### PR TITLE
Add binwarp mouse control mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -94,6 +94,7 @@ Advertise your module here, open a PR and include a org-mode link!
 ** Utilities
 - [[./util/alert-me/README.org][alert-me]] :: Alert me that an event is coming
 - [[./util/app-menu/README.org][app-menu]] :: A simple application menu for launching shell commands
+- [[./util/binwarp/README.org][binwarp]] :: Keyboard-driven divide-and-conquer mouse control mode.
 - [[./util/browse/README.org][browse]] :: Open the default web browser portably
 - [[./util/clipboard-history/README.org][clipboard-history]] :: Simple clipboard history module for StumpWM
 - [[./util/command-history/README.org][command-history]] :: Save and load the stumpwm::*input-history* to a file

--- a/README.org
+++ b/README.org
@@ -94,6 +94,7 @@ Advertise your module here, open a PR and include a org-mode link!
 ** Utilities
 - [[./util/alert-me/README.org][alert-me]] :: Alert me that an event is coming
 - [[./util/app-menu/README.org][app-menu]] :: A simple application menu for launching shell commands
+- [[./util/beckon/README.org][beckon]] :: Beckon the mouse to the current window
 - [[./util/binwarp/README.org][binwarp]] :: Keyboard-driven divide-and-conquer mouse control mode.
 - [[./util/browse/README.org][browse]] :: Open the default web browser portably
 - [[./util/clipboard-history/README.org][clipboard-history]] :: Simple clipboard history module for StumpWM

--- a/util/binwarp/README.org
+++ b/util/binwarp/README.org
@@ -1,0 +1,99 @@
+* Binwarp
+
+Binwarp (binary mouse warping) is a new keymap and mode that enables you to (almost) 
+get rid of mouse and go even more keyboard-driven! Moreover, with enough muscle memory, 
+you can be even more productive than with mouse, because Binwarp uses a divide-and-conquer 
+approach and splits the screen in two on every `binwarp` you make. Given that,
+you can reach any pixel on your screen in less than 12 keypresses (on 1920x1080 screen),
+but you would rarely need exact pixels, so it's even less keypresses!
+
+This mode is somewhat similar to the software called [[https://github.com/jordansissel/keynav][keynav]],
+with the notable advantage that Binwarp is written on top of StumpWM and all the
+configuration can be done in Common Lisp, which is much more comfortable than
+configuring some non-lispy external tool.
+
+** Getting Started
+
+To start using Binwarp, just load it into your StumpWM setup by adding either
+#+BEGIN_SRC lisp
+(load-module "binwarp)
+#+END_SRC
+or
+#+BEGIN_SRC lisp 
+(asdf:load-system :binwarp)
+#+END_SRC
+to your config file.
+
+Then you need to explicitly create a binding for Binwarp, using `define-binwarp-mode`.
+
+#+BEGIN_SRC lisp
+(binwarp:define-binwarp-mode your-binwarp-mode-name "X" (:map *root-map*)
+    ((kbd "RET") "ratclick 1")
+    ((kbd "SPC") "ratclick 3"))
+#+END_SRC
+
+This example snippet creates an interactive keymap named =your-binwarp-mode-name= and binds 
+it to =C-t X= (in case your =*root-map*= prefix key is =C-t=), while adding the left mouse-click
+to the default binwarp keymap as =RET= key, and right mouse-click as =SPC=.
+You can look at =define-binwarp-mode= documentation to learn its capabilities.
+
+** Configuration variables
+
+Binwarp exports a bunch of special variables that influence its behavior in a way
+that can suit your workflow. The list is:
+
+- =*reinitiate-ptr*=
+- =*init-ptr-position*=
+- =*preserve-history*=
+
+See the respective documentation for the ways they can be used to enhance your binwarping!
+
+Also, there is =*default-binwarp-keymap*= that  you can alter to enable different keys for binwarping,
+although using =define-binwarp-mode= seems more straightforward to me.
+
+** Interaction with remapped keys
+
+Due to Binwarp being an =interactive-keymap=, there are some problems with using it 
+together with the remapped keys, and some keypresses can never get to Binwarp,
+sometimes with the terrible consequence that you won't be able to disable Binwarp
+or accidentaly destroy some part of your setup (only the former happened to me 
+and I hope that latter is just a joke).
+
+To get around this, you can use =lambda=-s as the conditions for your 
+=define-remapped-keys= and include =binwarp*binwarp-mode-p*= as one of the
+conditions for these remapped keys to not work for.
+
+For example, if you remap keys for Firefox (as I do), then your configuration
+should look like this:
+
+#+BEGIN_SRC lisp
+(define-remapped-keys
+    `((,(lambda (win)
+          (and (member (window-class win)
+                       '("Firefox" "IceCat" "Nightly")
+                       :test #'string-equal)
+               (not binwarp:*binwarp-mode-p*)))
+        ... your bindings ...)))
+#+END_SRC
+
+** Mouse-related utils
+
+Binwarp have two general mouse-related utils:
+
+- =with-pointer=, macro that binds the mouse coordinates to the variables
+  you name, and runs the given macro body in the scope where these variables are accessible.
+- =randwarp=, command for random mouse warping in a given direction. I can't come up with a good 
+use-case for that, but it's fun and gives your mouse-related experience a bit of cool randomness :)
+
+If you have ideas on the mouse-related utils that you want to see in Binwarp, you're welcome to suggest or even add them!
+
+** Wishlist
+
+- [ ] Add per-window binwarping.
+- [ ] Make =*binwarp-history*= tree-like, instead of list, to never lose the track of where you've been.
+- [ ] Make documentation clearer (because documentation is never exhaustive).
+- [ ] Integrate Binwarp into StumpWM (?) or come up with a simple way to use both Binwarp
+  and =define-remapped-keys= without shooting your feet off.
+- [ ] Use different directions from the ones provided by StumpWM. =:top-left= and 
+  similar ones would be especially handy for fast navigation.
+- [ ] Add the mouse keybindings (e.g., =ratclick 1= and =ratclick 3=) to the =*default-binwarp-keymap*=.

--- a/util/binwarp/binwarp.asd
+++ b/util/binwarp/binwarp.asd
@@ -1,0 +1,11 @@
+;;;; binwarp.asd
+
+(asdf:defsystem #:binwarp
+  :description "Keyboard-driven divide-and-conquer mouse control mode."
+  :author "Artyom Bologov"
+  :license "GPLv3"
+  :version "0.9"
+  :serial t
+  :depends-on (#:stumpwm)
+  :components ((:file "package")
+               (:file "binwarp")))

--- a/util/binwarp/binwarp.lisp
+++ b/util/binwarp/binwarp.lisp
@@ -1,0 +1,182 @@
+;;;; binwarp.lisp
+
+(in-package #:binwarp)
+
+(defvar *binwarp-mode-p*     nil "Whether you are in the binwarp mode.")
+(defvar *binwarp-area*       nil "The current screen area that binwarp is restricted by.")
+(defvar *binwarp-history*    '() "The list of previous binwarp areas.")
+(defvar *reinitiate-ptr*     nil "If non-nil, put pointer in *INIT-PTR-POSITION* upon BINWARP-MODE activation.")
+(defvar *init-ptr-position*  nil "Two-element list of PTR-X and PTR-Y to put the pointer at when binwarp-mode starts.")
+(defvar *preserve-history*   nil "Whether to keep binwarping history between sessions if non-nil.")
+
+(defclass binwarp-area ()
+  ((x      :initarg :x      :type 'integer :accessor x)
+   (y      :initarg :y      :type 'integer :accessor y)
+   (height :initarg :height :type 'integer :accessor height)
+   (width  :initarg :width  :type 'integer :accessor width)
+   (ptr-x                   :type 'integer :accessor ptr-x)
+   (ptr-y                   :type 'integer :accessor ptr-y)))
+
+(defun copy-binwarp-area (bw-area &key x y height width)
+  (make-instance 'binwarp-area
+                 :y (or y (y bw-area))
+                 :x (or x (x bw-area))
+                 :height (or height (height bw-area))
+                 :width (or width (width bw-area))))
+
+(defmacro with-pointer ((x-var y-var) &body body)
+  "Convenience macro to get the pointer position and bind it to the given variables,
+x coordinate to X-VAR and y coordinate to Y-VAR respectively."
+  `(multiple-value-bind (,x-var ,y-var)
+       (xlib:global-pointer-position *display*)
+     ,@body))
+
+(defcommand randwarp (direction &optional (maximum-step 10) (base-step 0)) (:direction :number :number)
+  "Ratwarps the pointer in the direction of DIRECTION to BASE-STEP pixels plus
+random number of pixels bounded by MAXIMUM-STEP"
+  (case direction
+    (:rigth (ratrelwarp (+ base-step (random maximum-step)) 0))
+    (:left  (ratrelwarp (+ (- base-step) (- (random maximum-step))) 0))
+    (:up    (ratrelwarp 0 (+ (- base-step) (- (random maximum-step)))))
+    (:down  (ratrelwarp 0 (+ base-step (random maximum-step))))
+    (t nil)))
+
+(defun binwarp-to-area (area)
+  "Warp the mouse to the mouse position stored in the given binwarp-AREA."
+  (ratwarp (ptr-x area) (ptr-y area)))
+
+(defun centered-warp (area)
+  "Ratwarp to the center on the binwarp-AREA."
+  (ratwarp (round (+ (x area) (/ (width  area) 2)))
+           (round (+ (y area) (/ (height area) 2)))))
+
+(defcommand init-binwarp () ()
+  "Default initialization function for Binwarp mode."
+  (let* ((screen (current-screen))
+         (x 0)
+         (y (if (and (stumpwm::head-mode-line (current-head))
+                     (eq *mode-line-position* :top))
+                (stumpwm::mode-line-height
+                 (stumpwm::head-mode-line (current-head)))
+                0))
+         (h (screen-height screen))
+         (w (screen-width screen)))
+    (setf *binwarp-area* (make-instance 'binwarp-area :x x :y y :height h :width w)
+          *binwarp-mode-p* t))
+  (when *reinitiate-ptr*
+    (apply #'ratwarp *init-ptr-position*)))
+
+(defcommand exit-binwarp () ()
+  "Default wrapping-up function for Binwarp mode."
+  (setf *binwarp-mode-p* nil
+        *binwarp-history* (when *preserve-history*
+                            *binwarp-history*)))
+
+(defcommand back-binwarp () ()
+  "Return to the previous binwarp area and mouse position.
+Be careful, the history movement is not tree-like and is destructive!
+
+You won't be able to go back after you've gone back, I mean :)"
+  (when *binwarp-history*
+    (binwarp-to-area (setf *binwarp-area* (pop *binwarp-history*)))))
+
+(defcommand binwarp (direction) (:direction)
+  "Splits the current *BINWARP-AREA* in two over the pointer position and
+moves the pointer to the center of this area -- in the direction of the GRAVITY."
+  (with-pointer (pointer-x pointer-y)
+    (setf (ptr-x *binwarp-area*) pointer-x
+          (ptr-y *binwarp-area*) pointer-y)
+    (push *binwarp-area* *binwarp-history*)
+    (setf *binwarp-area* (copy-binwarp-area
+                          *binwarp-area*
+                          :height (when (member direction '(:up :down))
+                                    (/ (height *binwarp-area*) 2))
+                          :y (when (eq direction :down)
+                               (+ (y *binwarp-area*)
+                                  (/ (height *binwarp-area*) 2)))
+                          :x (when (eq direction :right)
+                               (+ (x *binwarp-area*)
+                                   (/ (width *binwarp-area*) 2)))
+                          :width (when (member direction '(:left :right))
+                                   (/ (width *binwarp-area*) 2))))
+    (centered-warp *binwarp-area*)))
+
+(defvar *default-binwarp-keymap*
+  '(((stumpwm:kbd "Down") "binwarp down")
+    ((stumpwm:kbd "n") "binwarp down")
+    ((stumpwm:kbd "j") "binwarp-down")
+
+    ((stumpwm:kbd "Up") "binwarp up")
+    ((stumpwm:kbd "p") "binwarp up")
+    ((stumpwm:kbd "k") "binwarp up")
+
+    ((stumpwm:kbd "Right") "binwarp right")
+    ((stumpwm:kbd "f") "binwarp right")
+    ((stumpwm:kbd "l") "binwarp right")
+
+    ((stumpwm:kbd "Left") "binwarp left")
+    ((stumpwm:kbd "b") "binwarp left")
+    ((stumpwm:kbd "h") "binwarp left")
+
+    ((stumpwm:kbd "0") "init-binwarp")
+
+    ((stumpwm:kbd "C-z") "back-binwarp")
+    ((stumpwm:kbd "/") "back-binwarp")
+    ((stumpwm:kbd "u") "back-binwarp"))
+  "The default keymap for binwarping that tries to be comfortable for
+Emacs, CUA and Vi(m) users all at once.")
+
+(defmacro define-binwarp-mode (name key
+                               (&key
+                                  (map '*top-map*)
+                                  (exit-keys '((kbd "C-g") (kbd "ESC")))
+                                  (on-enter '#'binwarp:init-binwarp)
+                                  (on-exit  '#'binwarp:exit-binwarp)
+                                  (redefine-bindings nil))
+                               &body bindings)
+  "Macro you'd most probably use in your config.
+
+NAME has the same constraints as the name of for the `define-interactive-keymap'.
+KEY should be a string to be passed to `kbd'.
+MAP should be a keymap. It's `*top-map*' by default.
+ON-ENTER, ON-EXIT are the same as is `define-interactive-keymap'.
+EXIT-KEYS are the same as `:exit-on' of `define-interactive-keymap'.
+REDEFINE-BINDINGS defines whether the BINDINGS will be appended
+to the `*default-binwarp-keymap*' if it's nil, and replace
+the default keymap otherwise.
+
+And BINDINGS follow the lambda list as an implicit list.
+
+Examples:
+
+\(binwarp:define-binwarp-mode binwarp-mode \"s-m\"
+  ((kbd \"C-n\") \"ratrelwarp  0 +5\")
+  ((kbd \"C-p\") \"ratrelwarp  0 -5\")
+  ((kbd \"C-f\") \"ratrelwarp +5  0\")
+  ((kbd \"C-b\") \"ratrelwarp -5  0\")
+
+  ((kbd \"RET\") \"ratclick 1\")
+  ((kbd \"SPC\") \"ratclick 3\"))
+
+This defines a binwarp-mode with additional bindings, and binds it to Super-m.
+
+\(binwarp:define-binwarp-mode binwarp-mode
+  \"M\" (:map *root-map*
+      :redefine-bindings t)
+  ((kbd \"a\") \"binwarp left\")
+  ((kbd \"w\") \"binwarp up\")
+  ((kbd \"s\") \"binwarp down\")
+  ((kbd \"d\") \"binwarp left\"))
+
+And this overrides the bindings to use WASD keys for binwarping
+and start it with C-t M (in case your prefix key is C-t.)"
+  `(progn
+     (define-interactive-keymap ,name
+         (:on-enter ,on-enter
+          :on-exit ,on-exit
+          :exit-on ,exit-keys)
+       ,@(unless redefine-bindings *default-binwarp-keymap*)
+       ,@bindings)
+     (define-key ,map (kbd ,key) ,(cond ((listp name) (symbol-name (second name)))
+                                        ((symbolp name) (symbol-name name))
+                                        (t name)))))

--- a/util/binwarp/package.lisp
+++ b/util/binwarp/package.lisp
@@ -1,0 +1,20 @@
+;;;; package.lisp
+
+(defpackage #:binwarp
+  (:use #:cl :stumpwm)
+  (:export #:*binwarp-mode-p*
+           #:*binwarp-area*
+           #:*binwarp-history*
+           #:*reinitiate-ptr*
+           #:*init-ptr-position*
+           #:*preserve-history*
+           #:*default-binwarp-keymap*
+           ;; Utils
+           #:with-pointer
+           #:randwarp
+           #:define-binwarp-mode
+           ;; Binwarping commands
+           #:init-binwarp
+           #:exit-binwarp
+           #:back-binwarp
+           #:binwarp))


### PR DESCRIPTION
This add a new interactive-keymap-based mouse control mode (in the sense of `iresize` mode and maybe even Emacs modes) -- Binwarp. It operates on restricted screen area and divides it in two on every action, making mouse movement into a recursive binary divide-and-conquer task.

Also, the `beacon` README entry was added when I ran `update-readme.sh`, so I included it in the PR as a separate commit.

### Motivation

This mode appeared when my laptop touchpad died and I felt a need in going mouse-less in domain of mouse control :) For now, this module is already covering all my needs and even has some configuration bits that I don't use, so I thought it can be useful for someone else.

If this is more suitable for `minor-mode` directory, I'll move it there.

I'll be glad if you could review it and point at some possibly unconventional or optimizable things!