### PR TITLE
update-readme.sh: Link to markdown file if one is present

### DIFF
--- a/update-readme.sh
+++ b/update-readme.sh
@@ -4,13 +4,9 @@ sed '/# --/q' README.org > tmpReadme
 
 for f in $(find . -name "*.asd" | sort);
 do
-    if [[ -f "$(dirname $f)/README.md" ]]; then
-        README_PATH="README.md"
-    else
-        README_PATH="README.org"
-    fi
+    README_PATH=$(ls $(dirname $f)/README{,.txt,.md,.org} 2>/dev/null)
     desc=$(grep description $f | grep -o \".*\" | sed 's,",,g');
-    echo - [[$(dirname $f)/${README_PATH}][$(basename $f .asd)]] :: ${desc} >> tmpReadme
+    echo - [[${README_PATH}][$(basename $f .asd)]] :: ${desc} >> tmpReadme
 done
 awk '/\/util\// && !x {print "** Utilities"; x=1} 1' tmpReadme > tmp; mv tmp tmpReadme
 awk '/\/media\// && !x {print "** Media"; x=1} 1' tmpReadme > tmp; mv tmp tmpReadme

--- a/update-readme.sh
+++ b/update-readme.sh
@@ -4,8 +4,13 @@ sed '/# --/q' README.org > tmpReadme
 
 for f in $(find . -name "*.asd" | sort);
 do
+    if [[ -f "$(dirname $f)/README.md" ]]; then
+        README_PATH="README.md"
+    else
+        README_PATH="README.org"
+    fi
     desc=$(grep description $f | grep -o \".*\" | sed 's,",,g');
-    echo - [[$(dirname $f)/README.org][$(basename $f .asd)]] :: $desc >> tmpReadme
+    echo - [[$(dirname $f)/${README_PATH}][$(basename $f .asd)]] :: ${desc} >> tmpReadme
 done
 awk '/\/util\// && !x {print "** Utilities"; x=1} 1' tmpReadme > tmp; mv tmp tmpReadme
 awk '/\/media\// && !x {print "** Media"; x=1} 1' tmpReadme > tmp; mv tmp tmpReadme


### PR DESCRIPTION
Update the `update-readme.sh` script so that the link in the top-level readme points to `README.md` ifone is present. Otherwise defaults to `README.org`