### PR TITLE
Add the stump-backlight module.

### DIFF
--- a/README.org
+++ b/README.org
@@ -118,6 +118,7 @@ Advertise your module here, open a PR and include a org-mode link!
 - [[./util/screenshot/README.org][screenshot]] :: Takes screenshots and stores them as png files
 - [[./util/searchengines/README.org][searchengines]] :: Allows searching text using prompt or clipboard contents with various search engines
 - [[./util/shell-command-history/README.org][shell-command-history]] :: Save and load the stumpwm::*input-shell-history* to a file
+- [[./util/stump-backlight/README.org][stump-backlight]] :: Native backlight control from StumpWM
 - [[./util/stump-nm/README.org][stump-nm]] :: StumpWM integration with NetworkManager
 - [[./util/surfraw/README.org][surfraw]] :: Integrates surfraw with stumpwm.
 - [[./util/swm-emacs/README.org][swm-emacs]] :: A set of utilities for launching the beast.

--- a/util/stump-backlight/README.org
+++ b/util/stump-backlight/README.org
@@ -1,0 +1,39 @@
+* stump-backlight
+
+This module allows you to manage the backlight natively with StumpWM.
+
+** Requirements
+
+None. This is done natively.
+
+** Usage
+
+Put the following in your =~/.stumpwmrc=:
+
+#+begin_src lisp
+  (load-module "stump-backlight")
+#+end_src
+
+And enjoy the backlight buttons working.
+
+** Details
+
+stump-backlight exposes a few things:
+
+- The =*scale*= variable: defaults to 10. It defines the scale of the
+  backlight. If you want more granularity than 10 steps, increase this variable.
+- The =*current-percent*= variable: defaults to 50. It defines the current
+  percentage of the backlight. Due to underlying technology issues, the
+  percentage is managed separately from the real one, so this lets you set it at
+  startup.
+- The =update= function: it takes the values from the variables and applies the
+  backlight.
+- 2 commands: =backlight-increase= and =backlight-decrease=. They increase or
+  decrease based on the scale and apply the backlight.
+
+The 2 commands are bound to those keys:
+
+#+begin_src lisp
+  (define-key *root-map* (kbd "XF86MonBrightnessUp") "backlight-increase")
+  (define-key *root-map* (kbd "XF86MonBrightnessDown") "backlight-decrease")
+#+end_src

--- a/util/stump-backlight/backlight.lisp
+++ b/util/stump-backlight/backlight.lisp
@@ -1,0 +1,45 @@
+(in-package #:stump-backlight)
+
+(defvar *scale* 10
+  "The backlight scale. Increase if you want more granularity.")
+
+(defvar *current-percent* 50
+  "CLX does not let us query the existing backlight, so we need to keep track of it.")
+
+(stumpwm:defcommand backlight-increase () ()
+  (when (< *current-percent* 100)
+    (setf *current-percent* (* (1+ (/ *current-percent* *scale*)) *scale*))
+    (update)))
+
+(stumpwm:defcommand backlight-decrease () ()
+  (when (> *current-percent* 0)
+    (setf *current-percent* (* (1- (/ *current-percent* *scale*)) *scale*))
+    (update)))
+
+(defun update ()
+  (let* ((window (stumpwm:window-xwin (stumpwm:current-window)))
+         (output (xlib:rr-get-output-primary window))
+         (backlight-limits
+           (multiple-value-list
+            (xlib:rr-query-output-property stumpwm:*display* output :backlight)))
+         (backlight-type (xlib:rr-get-output-property stumpwm:*display* output :backlight)))
+    (destructuring-bind (min max) (fourth backlight-limits)
+      (xlib:rr-change-output-property
+       stumpwm:*display*
+       output
+       :backlight
+       0 ; replace
+       (vector (scaled-current (1+ min) (1- max))) ; max is non-inclusive in X
+                                                   ; API, but inclusive in ours.
+       backlight-type))))
+
+(defun scaled-current (min max)
+  (truncate (/ (* *current-percent* (- max min)) 100)))
+
+;; Opinionated but this one should be fair.
+(stumpwm:define-key stumpwm:*top-map*
+    (stumpwm:kbd "XF86MonBrightnessUp")
+  "backlight-increase")
+(stumpwm:define-key stumpwm:*top-map*
+    (stumpwm:kbd "XF86MonBrightnessDown")
+  "backlight-decrease")

--- a/util/stump-backlight/package.lisp
+++ b/util/stump-backlight/package.lisp
@@ -1,0 +1,7 @@
+(defpackage #:stump-backlight
+  (:use #:cl)
+  (:export #:*current-percent*
+           #:*scale*
+           #:backlight-increase
+           #:backlight-decrease
+           #:update))

--- a/util/stump-backlight/stump-backlight.asd
+++ b/util/stump-backlight/stump-backlight.asd
@@ -1,0 +1,8 @@
+(defsystem "stump-backlight"
+  :serial t
+  :description "Native backlight control from StumpWM"
+  :author "Florian Margaine <florian@margaine.com>"
+  :license "GPLv3"
+  :depends-on ("clx" "stumpwm")
+  :components ((:file "package")
+               (:file "backlight")))


### PR DESCRIPTION
This module allows you to manage the backlight natively with StumpWM.

More details in the README.org file.

This is doing something a bit controversial: it binds 2 keys by default. However, those 2 keys have a single purpose, and this module's only responsibility is to fulfil this purpose, so I'd say it's fair. Happy to remove those keybindings and edit the README.org if it's too controversial.