### PR TITLE
fix stack exhaustion error

### DIFF
--- a/util/golden-ratio/swm-golden-ratio.lisp
+++ b/util/golden-ratio/swm-golden-ratio.lisp
@@ -11,18 +11,12 @@
 (defun resize-px (target current-px)
   (- target current-px))
 
-(defun balance-current-group ()
-  (stumpwm::balance-frames-internal (stumpwm:current-group)
-                                    (list (stumpwm::tile-group-frame-head
-                                           (stumpwm:current-group)
-                                           (stumpwm:current-head)))))
-
 (defun resize-to-golden-ratio (to-frame from-frame)
   (when (and *golden-ratio-on* (not (stumpwm::single-frame-p)))
     (let* ((target-x (target-px (stumpwm::head-width (stumpwm:current-head))))
            (target-y (target-px (stumpwm::head-height (stumpwm:current-head)))))
       (setq *golden-ratio-on* nil)
-      (balance-current-group)
+      (stumpwm:balance-frames)
       (stumpwm:resize (resize-px target-x
                                  (stumpwm::frame-width to-frame))
                       (resize-px target-y


### PR DESCRIPTION
Hi there.

I just noticed that an error happened whenever I switched focus with the golden-ratio-mode toggled on, and the resize action wasn't applied at all.

This patch removes all errors, and the behaviour is now as expected.

Sorry for not providing any further details, such as error logs, as I'm not yet acquainted with stumwm. I even tried connecting with SLIME to do that but the error was only displayed as a message by stumpwm. 

