### PR TITLE
Adds "Close Notification" dbus method, some apps (Firefox) need it

### DIFF
--- a/util/notify/notify.lisp
+++ b/util/notify/notify.lisp
@@ -96,11 +96,18 @@
   (:name "GetCapabilities")
   (values #("actions" "action-icons" "body" "body-markup")))
 
-(define-dbus-method (notify-dbus-service close-notification) ((returnId :uint32))
+;;; based on dbus notifications spec
+;;; https://specifications.freedesktop.org/notification-spec/latest/ar01s09.html
+(defconstant +close-notification-reason-expired+ 1)
+(defconstant +close-notification-reason-dismissed-by-user+ 2)
+(defconstant +close-notification-reason-closed+ 3)
+(defconstant +close-notification-reason-reserved+ 4)
+
+(define-dbus-method (notify-dbus-service close-notification) ((id :uint32))
     (:uint32 :uint32)
   (:interface "org.freedesktop.Notifications")
   (:name "CloseNotification")
-  (values returnId 3))
+  (values id +close-notification-reason-closed+))
 
 (defun notifications-listen ()
   (handler-case

--- a/util/notify/notify.lisp
+++ b/util/notify/notify.lisp
@@ -96,6 +96,12 @@
   (:name "GetCapabilities")
   (values #("actions" "action-icons" "body" "body-markup")))
 
+(define-dbus-method (notify-dbus-service close-notification) ((returnId :uint32))
+    (:uint32 :uint32)
+  (:interface "org.freedesktop.Notifications")
+  (:name "CloseNotification")
+  (values returnId 3))
+
 (defun notifications-listen ()
   (handler-case
       (with-open-bus (bus (session-server-addresses))


### PR DESCRIPTION
Some apps like Firefox seem to revert to showing built-in notifications when stumpwm/notify is used as a DBUS notifications handler. This commit fixes the issue