### PR TITLE
update for change in McCLIM internals

### DIFF
--- a/modeline/clim-mode-line/README.org
+++ b/modeline/clim-mode-line/README.org
@@ -28,7 +28,7 @@
   After that is completed, we can evaluate adding in a command reading system through the mode line. 
 
 * Todo List
-** TODO Fix Commands
-   Commands arent functioning currently.
+** TODO Fix Crashes
+   The mode line soft crashes when commands are executed. Sometimes it functions for a couple commands, other times a single command crashes it. A crash causes no condition to be signalled (they are possibly being caught in the refresh hook function) but rather causes the pane to go white - all output lost. 
 ** TODO Solve Threading Issues
    It is unclear whether crashes are caused by threading issues. This needs to be investigated and solved. 

--- a/modeline/clim-mode-line/README.org
+++ b/modeline/clim-mode-line/README.org
@@ -2,7 +2,7 @@
 #+AUTHOR: Shozo «szos at posteo dot net»
 
 * CLIM Mode Line
-  This is a project to write a dock using CLIM inspired by the emacs and stumpwm mode lines. 
+  This is a project to write a dock using CLIM inspired by the emacs and StumpWM mode lines. 
 
 ** Usage
    Currently the (imo) best way to utilize this modeline is to launch StumpWM as normal and then start a swank/slynk server and connect to it. From the repl evaluate 
@@ -22,24 +22,13 @@
    At this point the mode line should pop up. 
    - NB! If you kill the mode line process/thread, the built in stumpwm mode line wont return. To kill and restart the clim mode line interrupt the ~run-mode-line~ fuction we ran in our second repl (via =C-c C-c=) and abort the evaluation, then run the stumpwm command ~restart-soft~. This should bring back the built in mode line, and you can follow the steps above to reopen the clim mode line. If you dont have access to the second repl, you can evaluate the following in any repl connected to the image· ~(clim-mode-line::com-quit)~
 
-* Design Goals
-  The goal of this system is to suppland the built in stumpwm mode line and input line. To this end there are three general layouts/display items we need to make: 
-  1. we need a pane to display everything
-     - this is pretty easy, we already have it. its just an application pane we draw text to
-  2. We need an execute-extended-command pane
-     - this can be harder to implement. Its made easier by the fact that we wont have to wrap lines, but complicated by the fact that we need to accept arguments to some commands. Hopefully theres a built in modeline pane in drei or esa. 
-  3. We need to accept arguments and prompt the user. 
-     - This is probably the hardest part. What I think is the best course of action, is when accepting an extended command (think stumpwm colon commands) that takes arguments, we want to create a pop-up to accept them, and we want that pop up to not be managed by stumpwm and not relinquish focus to any other windows (aside from the mode line) until its finished getting the arguments. For example, we press =C-t ;= to open up the modeline execute-extended-command layout. we type in =Move Window To Group=, and a popup appears, asking us for the window and the group, while simultaneously the windows and groups in the mode line become active (through presentations) and clicking on them will satisfy that specific argument to the command we entered. Alternatively, we could type the window (name/number/class/title/etc) and the group (name/number/etc) in the popup, and then press meta-RET to submit it. 
+* Goals
+  The initial goal is to get a mode line esq application written in CLIM, which doesnt hang, and allows for CLIM commands to be dispatched via clicking on elements in the mode line.
 
-
+  After that is completed, we can evaluate adding in a command reading system through the mode line. 
 
 * Todo List
-** TODO Fix drag and drop translator
-   Drag and drop translator needs fixing, it is unclear why the second argument fails to be aquired.
-
-** TODO Update on window map/unmap
-   We want to update the frame whenever a map/unmap event occurs. This should probably be developed as a stumpwm mode line replacement and not a standalone dock/panel. Thus we can say with certainty that the mode line process will be within the same lisp image as stumpwm, and we can use stumpwm directly, and update the mode line directly from stumpwm. This also lets us get an idea of various other aspects, such as groups, heads, etc. 
-
-** TODO Fix Presentation Types
-   Presentation types need to be fleshed out. What we want to have happen is, for example, if 
-we define a command to move a window to a group, we want to be able to control-click on a window to select it, then click on a group and the window gets sent to that group. This is the same purpose as the drag and drop translator, but we want both working so we can define different behaviores for dragging vs clicking/keystrokes etc. 
+** TODO Fix Commands
+   Commands arent functioning currently.
+** TODO Solve Threading Issues
+   It is unclear whether crashes are caused by threading issues. This needs to be investigated and solved. 

--- a/modeline/clim-mode-line/clim-clx-patch.lisp
+++ b/modeline/clim-mode-line/clim-clx-patch.lisp
@@ -10,17 +10,16 @@
 (defmethod adopt-frame :after ((fm clx-frame-manager) (frame application-frame))
   (let ((sheet (slot-value frame 'top-level-sheet)))
     (let* ((top-level-sheet (frame-top-level-sheet frame))
-           (mirror (sheet-direct-xmirror top-level-sheet)))
+           (mirror (sheet-direct-mirror top-level-sheet)))
       (case (clim-extensions:find-frame-type frame)
         (:override-redirect (setf (xlib:window-override-redirect mirror) :on))
         (:dialog (xlib:change-property mirror
                                        :_NET_WM_WINDOW_TYPE
                                        (list (xlib:intern-atom (xlib:window-display mirror) :_NET_WM_WINDOW_TYPE_DIALOG))
                                        :atom 32))
-	(:dock (xlib:change-property mirror ; this form is the only new thing here. 
+	(:dock (xlib:change-property mirror
 				     :_NET_WM_WINDOW_TYPE
-				     (list (xlib:intern-atom (xlib:window-display mirror)
-							     :_NET_WM_WINDOW_TYPE_DOCK))
+				     (list (xlib:intern-atom (xlib:window-display mirror) :_NET_WM_WINDOW_TYPE_DOCK))
 				     :atom 32)))
       (multiple-value-bind (w h x y) (climi::frame-geometry* frame)
         (declare (ignore w h))
@@ -37,7 +36,7 @@
       ;; Care for calling-frame, be careful not to trip on missing bits
       (let* ((calling-frame (frame-calling-frame frame))
              (tls (and calling-frame (frame-top-level-sheet calling-frame)))
-             (calling-mirror (and tls (sheet-xmirror tls))))
+             (calling-mirror (and tls (sheet-mirror tls))))
         (when calling-mirror
           (setf (xlib:transient-for mirror)
                 calling-mirror)))

--- a/modeline/clim-mode-line/clim-mode-line.asd
+++ b/modeline/clim-mode-line/clim-mode-line.asd
@@ -10,5 +10,6 @@
   :components ((:file "package")
 	       (:file "clim-clx-patch")
                (:file "clim-mode-line")
-	       (:file "mode-line-formatters")
+               (:file "presentations")
+               (:file "mode-line-formatters")
 	       (:file "stumpwm-patch")))

--- a/modeline/clim-mode-line/clim-mode-line.lisp
+++ b/modeline/clim-mode-line/clim-mode-line.lisp
@@ -4,24 +4,26 @@
 
 (defvar *mode-line-active* nil)
 (defvar *default-mode-line-function* 'format-mode-line)
-(defparameter *mode-line-active-formatters* '((format-nil format-groups format-windows)))
+(defparameter *mode-line-active-formatters* '((format-groups format-windows)))
 
 (define-application-frame clim-mode-line () ()
-  ;; (:top-level ) ; unsure if we want a custom toplevel or if our method will work fine
   (:panes (display :application
 		   :display-function 'clim-mode-line-display-function
 		   ;; :width 1920
 		   ;; :height 10
+                   :incremental-redisplay t
 		   :scroll-bars nil
 		   :borders nil)
 	  ;; We should add an execute-extended-command, and switch to a layout containing that when
 	  ;; one calls colon. 
-	  (colon :modeline))
+	  ;; (colon :modeline)
+          )
   (:layouts
    (default display)
-   (input colon)
-   (display+input (horizontally ()
-		    display colon))))
+   ;; (input colon)
+   ;; (display+input (horizontally ()
+   ;;      	    display colon))
+   ))
 
 (define-clim-mode-line-command (com-quit) ()
   (frame-exit (or *application-frame*
@@ -34,9 +36,9 @@
 (defun mode-line-active? ()
   *mode-line-active*)
 
-(defun run-mode-line ()
+(defun run-mode-line (&key (height 20))
   (let ((frame (make-application-frame 'clim-mode-line
-				       :height 20)))
+				       :height height)))
     (setf *mode-line-active* t)
     (run-frame-top-level frame)))
 
@@ -47,40 +49,3 @@
 (defmethod clime:find-frame-type ((frame clim-mode-line)) 
   "this method sets the window type via clim-clx::adopt-frame as defined below."
   :dock)
-
-(defmethod default-frame-top-level
-    ((frame clim-mode-line)
-     &key (command-parser 'command-line-command-parser)
-       (command-unparser 'command-line-command-unparser)
-       (partial-command-parser
-	'command-line-read-remaining-arguments-for-partial-command)
-       (prompt "Command: "))
-  (declare (ignore prompt))
-  ;; Give each pane a fresh start first time through.
-  (loop
-      ;; The variables are rebound each time through the loop because the
-      ;; values of frame-standard-input et al. might be changed by a command.
-      ;;
-      ;; We rebind *QUERY-IO* ensuring variable is always a stream,
-      ;; but we use FRAME-QUERY-IO for our own actions and to decide
-      ;; whenever frame has the query IO stream associated with it..
-      (let* ((frame-query-io (frame-query-io frame))
-	     (*standard-input*  (or (frame-standard-input frame)  *standard-input*))
-	     (*standard-output* (or (frame-standard-output frame) *standard-output*))
-	     (*query-io* (or frame-query-io *query-io*))
-	     ;; during development, don't alter *error-output*
-	     ;; (*error-output* (frame-error-output frame))
-	     (*pointer-documentation-output* (frame-pointer-documentation-output frame))
-	     (*command-parser* command-parser)
-	     (*command-unparser* command-unparser)
-	     (*partial-command-parser* partial-command-parser))
-	(restart-case
-	    (flet ((execute-command ()
-		     (let ((command (read-frame-command frame :stream frame-query-io)))
-		       (when command
-			 (execute-frame-command frame command)))))
-	      (redisplay-frame-panes frame :force-p t)
-	      (execute-command))
-	  (abort ()
-	    :report "Return to application command loop."
-	    (beep))))))

--- a/modeline/clim-mode-line/clim-mode-line.lisp
+++ b/modeline/clim-mode-line/clim-mode-line.lisp
@@ -11,7 +11,7 @@
 		   :display-function 'clim-mode-line-display-function
 		   ;; :width 1920
 		   ;; :height 10
-                   :incremental-redisplay t
+                   ;; :incremental-redisplay t
 		   :scroll-bars nil
 		   :borders nil)
 	  ;; We should add an execute-extended-command, and switch to a layout containing that when
@@ -42,9 +42,15 @@
     (setf *mode-line-active* t)
     (run-frame-top-level frame)))
 
-(defun redisplay-clim-mode-line (&optional (ml (find-application-frame 'clim-mode-line :create nil :activate nil)))
-  (when ml
-    (redisplay-frame-panes ml :force-p t)))
+(defvar *redisplay-mode-line-lock* (bt:make-lock "cml-lock"))
+
+(defun redisplay-clim-mode-line (&optional (ml (find-application-frame
+                                                'clim-mode-line
+                                                :create nil
+                                                :activate nil)))
+  (bt:with-lock-held (*redisplay-mode-line-lock*)
+    (when ml
+      (redisplay-frame-panes ml :force-p t))))
 
 (defmethod clime:find-frame-type ((frame clim-mode-line)) 
   "this method sets the window type via clim-clx::adopt-frame as defined below."

--- a/modeline/clim-mode-line/mode-line-formatters.lisp
+++ b/modeline/clim-mode-line/mode-line-formatters.lisp
@@ -1,16 +1,29 @@
-;;;; mode-line-formatters.lisp
 (in-package :clim-mode-line)
 
-;;;; Formatters for clim-mode-line are markedly different from the formatters
-;;;; for the stumpwm mode line. While I think a translator could be written,
-;;;; at the moment we will just focus on the formatters native to clim-mode-line
+(defun format-groups (frame pane)
+  (declare (ignore frame))
+  (slim:cell (format pane "["))
+  (loop for group in (stumpwm::sort-groups (stumpwm:current-screen))
+        with current = (stumpwm:current-group)
+        do (slim:cell
+             (if (eql group current)
+                 (with-drawing-options (pane :ink +red+)
+                   (present group 'stumpwm::group :stream pane :single-box t))
+                 (present group 'stumpwm::group :stream pane :single-box t))))
+  (slim:cell (format pane "]")))
 
-
-;;;; Default formatters are functions that take a frame and a pane, and write output
-;;;; via calls to slim:cell. slim:cell is the only thing that should be used, as by
-;;;; default the functions will be wrapped in calls to slim:with-table, slim:row,
-;;;; and slim:col.
-
+(defun format-windows (frame pane)
+  (declare (ignore frame))
+  (slim:cell (format pane "["))
+  (loop for window in (stumpwm::sort-windows (stumpwm:current-group))
+        with current = (stumpwm:current-window)
+        do (slim:cell (if (eql window current)
+                          (with-drawing-options (pane :ink +red+)
+                            (present window 'stumpwm::window :stream pane
+                                                             :single-box t))
+                          (present window 'stumpwm::window :stream pane
+                                                           :single-box t))))
+  (slim:cell (format pane "]")))
 
 (defun format-mode-line (frame pane)
   "As the default mode line formatting function, format-mode-line walks through the list of active 
@@ -24,181 +37,4 @@ formatters and calls them within the appropriate row/column configuration. "
 	    do (slim:row
 		 (loop for fn in flist
 		       do (slim:col (funcall fn frame pane))))))))
-
-(defun format-nil (frame pane)
-  (declare (ignore frame))
-  (slim:cell (format pane "NIL")))
-
-(let ((msg ""))
-  (defun format-msg (frame pane)
-    (declare (ignore frame))
-    (slim:cell (format pane "~a" msg)))
-  (defun set-msg (m)
-    (setf msg m)))
-
-(defparameter *selected* ;; (lambda (thing) thing)
-  nil
-  "every top priority click command must check if this is non-nil. if it is. they must call it and bind it to
-the value return by itself.")
-
-;;; Group formatting
-
-(define-gesture-name :right-click :pointer-button-press (:right))
-(define-gesture-name :left-ctrl-click :pointer-button-press (:left :control))
-(define-gesture-name :left-meta-click :pointer-button-press (:left :meta))
-
-;;; We need a presentation type for groups.
-(define-presentation-type stumpwm-group-presentation ())
-
-;; (define-clim-mode-line-command (com-move-window-to-group-2arg)
-;;     ((window stumpwm::window) (group stumpwm::group))
-;;   (stumpwm::move-window-to-group window group))
-
-(define-drag-and-drop-translator drag-window (stumpwm-window-presentation command stumpwm-group-presentation
-									  clim-mode-line
-									  :gesture :left-meta-click)
-				 (object cmd destination)
-  `(stumpwm::message "~a" '(,object ,cmd ,destination)))
-
-;; (define-drag-and-drop-translator drag-group (stumpwm-group-presentation command stumpwm-window-presentation
-;; 									  clim-mode-line
-;; 									  :gesture :left-meta-click
-;; 									  ;; :priority 9
-;; 									)
-;; 				 (object destination)
-;;   `(com-move-window-to-group-2arg ,destination ,object))
-
-;; (define-drag-and-drop-translator stumpwm-window-to-group-drag-and-drop-translator
-;;     (stumpwm-window-presentation command stumpwm-group-presentation clim-mode-line
-;; 				 :documentation "Move Window to Group"
-;; 				 :gesture :left-ctrl-click)
-;;     (window group)
-;;   `(com-move-window-to-group-2arg ,window ,group))
-
-;;; now we define commands and their presentation to command translators.
-(define-clim-mode-line-command (com-switch-to-group++)
-    ((group stumpwm::group))
-  "this command must do its own checking to see if it is supposed to move a window to this group... 
-there must be a better way to do this... this is rediculous!!"
-  (if (typep (move-window-to-group-item) 'stumpwm::window)
-      (com-move-window-to-group group)
-      (stumpwm::switch-to-group group)))
-
-(define-presentation-to-command-translator group-switch
-    (stumpwm-group-presentation com-switch-to-group++ clim-mode-line
-     :gesture :select
-     :priority 9
-     :documentation "Switch to group")
-    (group)
-  (list group))
-
-;; (define-presentation-method )
-
-(define-clim-mode-line-command (com-kill-group :name t)
-    ((group t))
-  (when (typep group 'stumpwm::group)
-    (let* ((groups (stumpwm::screen-groups (stumpwm::group-screen group)))
-	   (to-group (or (stumpwm::next-group group (stumpwm::non-hidden-groups groups))
-			 (stumpwm::next-group group groups))))
-      (when to-group
-	(stumpwm::kill-group group to-group)))))
-
-(define-presentation-to-command-translator group-kill
-    (stumpwm-group-presentation com-kill-group clim-mode-line
-     :priority 0)
-    (group)
-  (list group))
-
-(define-presentation-to-command-translator group-move-window-to-group
-    (stumpwm-group-presentation com-move-window-to-group clim-mode-line
-     :priority 8)
-    (group)
-  (list group))
-
-(let ((item nil))
-  (define-clim-mode-line-command (com-move-window-to-group)
-      ((group stumpwm::group))
-    (if (typep item 'stumpwm::window)
-	(prog1 (stumpwm::move-window-to-group item group)
-	  (setf item nil))
-	(setf item group)))
-  (defun move-window-to-group-item (&optional (set-to nil set-to-provided-p))
-    (when set-to-provided-p (setf item set-to))
-    item)
-  (define-clim-mode-line-command (com-to-group-move-window)
-      ((window stumpwm::window))
-    (if (typep item 'stumpwm::group)
-	(prog1 (stumpwm::move-window-to-group window item)
-	  (setf item nil))
-	(setf item window))))
-
-(defgeneric get-presentation-using-selected (presentation-type-symbol)
-  (:method (sym) sym)
-  (:method ((sym (eql 'stumpwm-group-presentation)))
-    (cond ((typep *selected-item* 'stumpwm::window)
-	   'stumpwm-move-window-to-group-presentation)
-  	  (t sym))))
-
-;; (with-output-to-presentation (pane group (dispatch-on-selected 'stumpwm-group-presentation)))
-
-(defun format-groups (frame pane)
-  (declare (ignore frame))
-  (slim:cell (format pane "["))
-  (loop for group in (stumpwm::sort-groups (stumpwm:current-screen))
-	do (slim:cell
-	    (if (equal group (stumpwm:current-group))
-		(with-output-as-presentation (pane group ;; 'stumpwm-current-group-presentation
-						   'stumpwm-group-presentation
-						   :single-box t)
-		  (with-drawing-options (pane :ink +red+)
-		    (format pane "~a" (stumpwm:group-name group))))
-		(with-output-as-presentation (pane group 'stumpwm-group-presentation
-						   ;; (get-presentation-using-selected )
-						   :single-box t)
-		  (format pane "~a" (stumpwm:group-name group))))))
-  (slim:cell (format pane "]")))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Window Formatting ;;; 
-;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(define-presentation-type stumpwm-window-presentation ())
-(define-presentation-to-command-translator window-move-window-to-group
-    (stumpwm-window-presentation com-to-group-move-window clim-mode-line
-     :priority 8)
-    (window)
-  (list window))
-
-(define-presentation-to-command-translator focus-window
-    (stumpwm-window-presentation com-focus-window clim-mode-line
-     :priority 9)
-    (window)
-  (list window))
-(define-clim-mode-line-command (com-focus-window)
-    ((window stumpwm::window))
-  (when (typep window 'stumpwm::window)
-    (stumpwm::focus-all window)))
-
-(defun format-windows (frame pane)
-  (declare (ignore frame))
-  (slim:cell (format pane "["))
-  (loop for window in (stumpwm::sort-windows-by-number (stumpwm::group-windows (stumpwm::current-group)))
-	do (slim:cell
-	     (if (equal (stumpwm::current-window) window)
-		 (with-drawing-options (pane :ink +red+)
-		   (with-output-as-presentation (pane window 'window ;; 'stumpwm-window-presentation
-						      :single-box t)
-		     (format pane "~a" (stumpwm::format-expand stumpwm:*window-formatters*
-							       stumpwm:*window-format*
-							       window))))
-		 (with-output-as-presentation (pane window 'window ;; 'stumpwm-window-presentation
-						    :single-box t)
-		   (format pane "~a" (stumpwm::format-expand stumpwm:*window-formatters*
-							     stumpwm:*window-format*
-							     window))))))
-  (slim:cell (format pane "]")))
-
-
-;; (define-presentation-to-command-translator focus-window
-;;     (stumpwm-window-presentation ))
 

--- a/modeline/clim-mode-line/mode-line-formatters.lisp
+++ b/modeline/clim-mode-line/mode-line-formatters.lisp
@@ -6,10 +6,7 @@
   (loop for group in (stumpwm::sort-groups (stumpwm:current-screen))
         with current = (stumpwm:current-group)
         do (slim:cell
-             (if (eql group current)
-                 (with-drawing-options (pane :ink +red+)
-                   (present group 'stumpwm::group :stream pane :single-box t))
-                 (present group 'stumpwm::group :stream pane :single-box t))))
+             (present group 'stumpwm::group :stream pane :single-box t)))
   (slim:cell (format pane "]")))
 
 (defun format-windows (frame pane)
@@ -17,13 +14,11 @@
   (slim:cell (format pane "["))
   (loop for window in (stumpwm::sort-windows (stumpwm:current-group))
         with current = (stumpwm:current-window)
-        do (slim:cell (if (eql window current)
-                          (with-drawing-options (pane :ink +red+)
-                            (present window 'stumpwm::window :stream pane
-                                                             :single-box t))
-                          (present window 'stumpwm::window :stream pane
-                                                           :single-box t))))
-  (slim:cell (format pane "]")))
+        do (slim:cell (present window 'stumpwm::window :stream pane
+                                                       :single-box t)))
+  (slim:cell (format pane "]"))
+  ;; (slim:cell (format pane "Current Window: ~A" (stumpwm:current-window)))
+  )
 
 (defun format-mode-line (frame pane)
   "As the default mode line formatting function, format-mode-line walks through the list of active 
@@ -31,7 +26,6 @@ formatters and calls them within the appropriate row/column configuration. "
   (let ((flists (if (functionp (car *mode-line-active-formatters*))
 		    (list *mode-line-active-formatters*)
 		    *mode-line-active-formatters*)))
-    ;; (dragging-output (pane)) ; useful? 
     (slim:with-table (pane)
       (loop for flist in flists
 	    do (slim:row

--- a/modeline/clim-mode-line/mode-line-formatters.lisp
+++ b/modeline/clim-mode-line/mode-line-formatters.lisp
@@ -13,9 +13,14 @@
   (declare (ignore frame))
   (slim:cell (format pane "["))
   (loop for window in (stumpwm::sort-windows (stumpwm:current-group))
-        with current = (stumpwm:current-window)
-        do (slim:cell (present window 'stumpwm::window :stream pane
-                                                       :single-box t)))
+        ;; with current = (stumpwm:current-window)
+        ;; if (eq current window)
+        ;;   do (with-drawing-options (pane :ink +red+)
+        ;;        (slim:cell (present window 'stumpwm::window :stream pane
+        ;;                                                    :single-box t)))
+        ;; else
+          do (slim:cell (present window 'stumpwm::window :stream pane
+                                                         :single-box t)))
   (slim:cell (format pane "]"))
   ;; (slim:cell (format pane "Current Window: ~A" (stumpwm:current-window)))
   )

--- a/modeline/clim-mode-line/presentations.lisp
+++ b/modeline/clim-mode-line/presentations.lisp
@@ -1,0 +1,118 @@
+(in-package :clim-mode-line)
+
+;;; Presentation Methods
+
+(define-presentation-method present
+    (window (type stumpwm::window) stream view &key)
+  (let ((str (string-trim '(#\space) (stumpwm::format-expand
+                                      stumpwm::*window-formatters*
+                                      stumpwm::*window-format*
+                                      window))))
+    (format stream "~A" str)))
+
+(define-presentation-method present
+    (group (type stumpwm::group) stream view &key)
+  (format stream "~A" (stumpwm:group-name group)))
+
+;;; Commands
+
+(define-clim-mode-line-command (com-move-to-group)
+    ((group stumpwm::group))
+  (stumpwm::switch-to-group group))
+
+(define-clim-mode-line-command (com-kill-group)
+    ((dead-group stumpwm::group))
+  (let* ((groups (stumpwm:screen-groups (stumpwm:current-screen)))
+         (to-group (or (stumpwm::next-group dead-group
+                                            (stumpwm::non-hidden-groups groups))
+                       (stumpwm::next-group dead-group groups))))
+    (if to-group
+        (let ((dead-group-name (stumpwm:group-name dead-group)))
+          (stumpwm::switch-to-group to-group)
+          (stumpwm::kill-group dead-group to-group)
+          (stumpwm::message "Deleted ~a." dead-group-name))
+        (stumpwm::message "There's only one group left."))))
+
+(define-clim-mode-line-command (com-kill-group-dragged)
+    ((dead-group stumpwm::group) (to-group stumpwm::group))
+  (stumpwm::switch-to-group to-group)
+  (stumpwm::kill-group dead-group to-group)
+  (stumpwm::message "Deleted ~a." dead-group-name))
+
+(define-clim-mode-line-command (com-move-window-into-group)
+    ((window stumpwm::window) (group stumpwm::group))
+  (stumpwm::message "moving window ~a into group ~a"
+                    (stumpwm::window-name window)
+                    (stumpwm::group-name group))
+  (handler-case (stumpwm::pull-to-group window group)
+    (error ()
+      (stumpwm::message "an error was encountered"))))
+
+(define-clim-mode-line-command (com-focus-window)
+    ((window stumpwm::window))
+  (stumpwm::group-focus-window (stumpwm::window-group window) window))
+
+(define-clim-mode-line-command (com-delete-window)
+    ((window stumpwm::window))
+  (stumpwm:delete-window window)
+  ;; (redisplay-clim-mode-line)
+  (window-refresh (find-pane-named *application-frame* 'display)))
+
+(define-clim-mode-line-command (com-kill-window)
+    ((window stumpwm::window))
+  (stumpwm:kill-window window))
+
+(define-clim-mode-line-command (com-renumber-window)
+    ((window stumpwm::window))
+  (let ((group (window-group window))
+        (nf (window-number window))
+        (win (find-if #'(lambda (win)
+                          (= (window-number win) nt))
+                      (group-windows group))))
+    (if win
+        (progn
+          (setf (window-number win) nf)
+          (setf (window-number window) nt))
+        (setf (window-number window) nt))))
+
+;;; Gestures
+
+(define-gesture-name :meta-left-click :pointer-button-press (:left :meta))
+
+;;; presentation to command translators
+
+(define-presentation-to-command-translator cml-select-group
+    (stumpwm::group com-move-to-group clim-mode-line
+     :priority 9)
+    (group)
+  (list group))
+
+(define-presentation-to-command-translator cml-kill-group
+    (stumpwm::group com-kill-group clim-mode-line
+     :priority 0)
+    (group)
+  (list group))
+
+(define-presentation-to-command-translator cml-select-window
+    (stumpwm::window com-focus-window clim-mode-line
+     :priority 9)
+    (window)
+  (list window))
+
+(define-presentation-to-command-translator cml-delete-window
+    (stumpwm::window com-delete-window clim-mode-line
+     :priority 1 :gesture :meta-left-click)
+    (window)
+  (list window))
+
+;;; D&D translators
+
+(define-drag-and-drop-translator cml-move-window-to-group
+    (stumpwm::window command stumpwm::group clim-mode-line)
+    (object destination-object)
+  `(com-move-window-into-group ,object ,destination-object))
+
+(define-drag-and-drop-translator cml-group-absorb-window
+    (stumpwm::group command stumpwm::window clim-mode-line)
+    (object destination-object)
+  `(com-move-window-into-group ,destination-object ,object))

--- a/modeline/clim-mode-line/presentations.lisp
+++ b/modeline/clim-mode-line/presentations.lisp
@@ -1,5 +1,8 @@
 (in-package :clim-mode-line)
 
+(defvar *current-group-color* +red+)
+(defvar *current-window-color* +red+)
+
 ;;; Presentation Methods
 
 (define-presentation-method present
@@ -7,12 +10,20 @@
   (let ((str (string-trim '(#\space) (stumpwm::format-expand
                                       stumpwm::*window-formatters*
                                       stumpwm::*window-format*
-                                      window))))
-    (format stream "~A" str)))
+                                      window)))
+        (curwin (stumpwm:current-window)))
+    (if (eq curwin window)
+        (with-drawing-options (stream :ink *current-window-color*)
+          (format stream "~A" str))
+        (format stream "~A" str))))
 
 (define-presentation-method present
     (group (type stumpwm::group) stream view &key)
-  (format stream "~A" (stumpwm:group-name group)))
+  (let ((curgrp (stumpwm:current-group)))
+    (if (eq curgrp group)
+        (with-drawing-options (stream :ink *current-group-color*)
+          (format stream "~A" (stumpwm:group-name group)))
+        (format stream "~A" (stumpwm:group-name group)))))
 
 ;;; Commands
 
@@ -54,9 +65,7 @@
 
 (define-clim-mode-line-command (com-delete-window)
     ((window stumpwm::window))
-  (stumpwm:delete-window window)
-  ;; (redisplay-clim-mode-line)
-  (window-refresh (find-pane-named *application-frame* 'display)))
+  (stumpwm:delete-window window))
 
 (define-clim-mode-line-command (com-kill-window)
     ((window stumpwm::window))

--- a/modeline/clim-mode-line/presentations.lisp
+++ b/modeline/clim-mode-line/presentations.lisp
@@ -11,9 +11,10 @@
                                       stumpwm::*window-formatters*
                                       stumpwm::*window-format*
                                       window)))
-        (curwin (stumpwm:current-window)))
+        (curwin (stumpwm:current-window))
+        )
     (if (eq curwin window)
-        (with-drawing-options (stream :ink *current-window-color*)
+        (with-drawing-options (stream :ink +red+)
           (format stream "~A" str))
         (format stream "~A" str))))
 
@@ -21,7 +22,7 @@
     (group (type stumpwm::group) stream view &key)
   (let ((curgrp (stumpwm:current-group)))
     (if (eq curgrp group)
-        (with-drawing-options (stream :ink *current-group-color*)
+        (with-drawing-options (stream :ink +red+)
           (format stream "~A" (stumpwm:group-name group)))
         (format stream "~A" (stumpwm:group-name group)))))
 

--- a/modeline/clim-mode-line/stumpwm-patch.lisp
+++ b/modeline/clim-mode-line/stumpwm-patch.lisp
@@ -1,36 +1,12 @@
 (in-package :stumpwm)
 
-;;; We want to redisplay our clim mode line every time a command is run. 
+;;; We want to redisplay our clim mode line every time a command is run.
 
-(defun eval-command (cmd &optional interactivep)
-  "exec cmd and echo the result."
-  (labels ((parse-and-run-command (input)
-             (let* ((arg-line (make-argument-line :string input
-                                                  :start 0))
-                    (cmd (argument-pop arg-line)))
-               (let ((*interactivep* interactivep))
-                 (call-interactively cmd arg-line)))))
-    (multiple-value-bind (result error-p)
-        ;; this fancy footwork lets us grab the backtrace from where the
-        ;; error actually happened.
-        (restart-case
-            (handler-bind
-                ((error (lambda (c)
-                          (invoke-restart 'eval-command-error
-                                          (format nil "^B^1*Error In Command '^b~a^B': ^n~A~a"
-                                                  cmd c (if *show-command-backtrace*
-                                                            (backtrace-string) ""))))))
-              (parse-and-run-command cmd))
-          (eval-command-error (err-text)
-            :interactive (lambda () nil)
-            (values err-text t)))
-      ;; interactive commands update the modeline
-      (update-all-mode-lines)
+(defun refresh-clim-mode-line-hook-fn (&rest ignore)
+  (declare (ignore ignore))
+  (handler-case 
       (clim-mode-line::redisplay-clim-mode-line)
-      (cond ((stringp result)
-             (if error-p
-                 (message-no-timeout "~a" result)
-                 (message "~a" result)))
-            ((eq result :abort)
-             (unless *suppress-abort-messages*
-               (message "Abort.")))))))
+    (error () nil)))
+
+(add-hook *event-processing-hook* 'refresh-clim-mode-line-hook-fn)
+


### PR DESCRIPTION
Because were patching McCLIM internals, we need to keep up to date
with McCLIM itself. sheet-direct-xmirror has been changed to
sheet-direct-mirror, and we need to reflect that change in order to
use McCLIM. There is a PR open with McCLIM to implement this, but until they merge that (or inform of a different preferred way of making a window to dock type) this method needs to be tracked and kept up to date with McCLIM. 

additionally, majorly reworked how groups/windows are presented, such that now we can present groups/windows to a stream instead of using `with-output-as-presentation`. this new way is cleaner and more in line with how clim is designed to be used. Also updated readme with a clearer explanation of what needs to be done. 