### PR TITLE
Add area-selection screenshot functionality

### DIFF
--- a/util/screenshot/screenshot.lisp
+++ b/util/screenshot/screenshot.lisp
@@ -1,16 +1,26 @@
 (in-package #:screenshot)
 
-(export '(screenshot screenshot-window))
+(export '(screenshot screenshot-window screenshot-area))
 
-(defun %screenshot-window (drawable file &key (height (xlib:drawable-height drawable))
-                                           (width (xlib:drawable-width drawable)))
+(defun colorname-to-color (colorname)
+  (let* ((screen (stumpwm:current-screen))
+         (colormap (xlib:screen-default-colormap (stumpwm:screen-number screen)))
+         (color (xlib:lookup-color colormap colorname)))
+    (xlib:alloc-color colormap color)))
+
+(defun %screenshot-window (drawable file
+                           &key
+                             (x 0)
+                             (y 0)
+                             (height (xlib:drawable-height drawable))
+                             (width (xlib:drawable-width drawable)))
   (let* ((png (make-instance 'pixel-streamed-png
                              :color-type :truecolor-alpha
                              :width width
                              :height height)))
     (multiple-value-bind (pixarray depth visual)
-        (xlib:get-raw-image drawable :x 0 :y 0 :width width :height height
-                            :format :Z-PIXMAP)
+        (xlib:get-raw-image drawable :x x :y y :width width :height height
+                                     :format :Z-PIXMAP)
       (declare (ignore depth visual))
       (with-open-file (stream file
                               :direction :output
@@ -36,6 +46,88 @@
                                 #xFF)
                           png))))
         (finish-png png)))))
+
+(defun clamp-xy (x1 y1 x2 y2)
+  (values (max x1 0)
+          (max y1 0)
+          (max (+ 2 x1) x2)
+          (max (+ 2 y1) y2)))
+
+(stumpwm:defcommand screenshot-area
+    (filename)
+    ((:rest "Filename: "))
+  "Make screenshot of selected area of display."
+  (let ((display stumpwm:*display*)
+        (x1 0)
+        (y1 0)
+        (x2 0)
+        (y2 0))
+    ;; The secret to drawing the selection rectangle comes from the xor function in the graphics context
+    ;; and the subwindow-mode :include-inferiors.
+    ;; https://askubuntu.com/questions/487725/how-can-i-draw-selection-rectangle-on-screen-for-my-script
+    (let* ((window (xlib:create-window
+                    :parent (xlib:screen-root (xlib:display-default-screen display))
+                    :x 0
+                    :y 0
+                    :width (stumpwm:screen-width (stumpwm:current-screen))
+                    :height (stumpwm:screen-height (stumpwm:current-screen))
+                    :background :none
+                    :event-mask '(:exposure :button-press :button-release)))
+           (gc (xlib:create-gcontext
+                :drawable window
+                :line-width 1
+                :foreground (colorname-to-color "green")
+                :function boole-xor
+                :subwindow-mode :include-inferiors)))
+      (unwind-protect
+           (progn
+             (xlib:map-window window)
+             (xlib:grab-pointer window '(:button-press :button-release :button-motion) :owner-p t)
+             (stumpwm:echo "Click and drag the area to screenshot.")
+             (xlib:event-case (display :discard-p t)
+               (exposure
+                ()
+                nil #| continue receiving events |#)
+               (motion-notify
+                (root-x root-y)
+                (multiple-value-bind (x1 y1 root-x root-y) (clamp-xy x1 y1 root-x root-y)
+                  ;; Since we're using that boole-xor function in the graphics context,
+                  ;; drawing over the old rectangle reverts the pixels back to their original values.
+                  (when x2
+                    (xlib:draw-rectangle window gc x1 y1 (- x2 x1) (- y2 y1)))
+                  (setf x2 root-x)
+                  (setf y2 root-y)
+                  ;; Now draw the new rectangle.
+                  (xlib:draw-rectangle window gc x1 y1 (- root-x x1) (- root-y y1)))
+                nil)
+               (button-press
+                ()
+                (multiple-value-bind (root-x root-y) (xlib:global-pointer-position display)
+                  (stumpwm:echo (format nil "Screenshotting from ~A, ~A to ..." root-x root-y))
+                  (setf x1 root-x)
+                  (setf y1 root-y)
+                  (setf x2 (+ 1 x1))
+                  (setf y2 (+ 1 y1))
+                  (xlib:draw-rectangle window gc x1 y1 (- x2 x1) (- y2 y1))
+                  nil))
+               (button-release
+                ()
+                (multiple-value-bind (root-x root-y) (xlib:global-pointer-position display)
+                  (multiple-value-bind (x1 y1 root-x root-y) (clamp-xy x1 y1 root-x root-y)
+                    ;; Since we're using that boole-xor function in the graphics context,
+                    ;; drawing over the old rectangle reverts the pixels back to their original values.
+                    (when x2
+                      (xlib:draw-rectangle window gc x1 y1 (- x2 x1) (- y2 y1)))
+                    (stumpwm:echo (format nil "Screenshotted from ~A, ~A to ~A, ~A to ~A" x1 y1 root-x root-y filename))
+                    (%screenshot-window (xlib:screen-root (stumpwm:screen-number (stumpwm:current-screen))) filename
+                                        :x (- x1 1)
+                                        :y (- y1 1)
+                                        :width (- (- root-x x1) 1)
+                                        :height (- (- root-y y1) 1))
+                    (xlib:ungrab-pointer display)
+                    (xlib:destroy-window window))
+                  t))))
+        (xlib:destroy-window window)))))
 
 (stumpwm:defcommand screenshot
     (filename)


### PR DESCRIPTION
Below is a demo screenshot that I took while creating this PR. 

I'm a bit new to X11, CommonLisp, and StumpWM, so any feedback on the code is appreciated. For example, I'm not sure if I need to be "unwind-protect -> destroying windows", or if there's a generally cleaner way to achieve this functionality. It works as-is for my use-case. 

[
![demo](https://user-images.githubusercontent.com/1719584/113446792-378d2b80-93be-11eb-8a71-deea0f37c515.png)
](url)

Referenced https://askubuntu.com/questions/487725/how-can-i-draw-selection-rectangle-on-screen-for-my-script for the code to get the selection rectangle redrawn as the mouse is moved.