### PR TITLE
Pomodoro tracker with stumptray notifications

### DIFF
--- a/README.org
+++ b/README.org
@@ -113,6 +113,7 @@ Advertise your module here, open a PR and include a org-mode link!
 - [[./util/passwd/README.org][passwd]] :: A simple password utility based on ironclad.
 - [[./util/perwindowlayout/README.org][perwindowlayout]] :: Change the keyboard layout per window.
 - [[./util/pinentry/README.org][pinentry]] :: Integrate GnuPG Agent with StumpWM
+- [[./util/pomodoro/README.org][swm-pomodoro]] :: Pretty basic Pomodoro-tracker for StumpWM.
 - [[./util/productivity/README.org][productivity]] :: Lock StumpWM down so you have to get work done.
 - [[./util/qubes/README.org][qubes]] :: Integration to Qubes OS (https://www.qubes-os.org)
 - [[./util/screenshot/README.org][screenshot]] :: Takes screenshots and stores them as png files

--- a/util/pomodoro/README.org
+++ b/util/pomodoro/README.org
@@ -1,0 +1,39 @@
+* Simple Pomodoro-tracker for StumpWM
+
+I needed one because I'm desperate, short on time
+and hate ticking sounds and blinking notifications.
+
+It's just an example of how fast and furious is StumpWM scripting.
+
+** Installation
+
+In your =~/.stumpwmrc=:
+
+#+begin_src lisp
+(load-module "notifications")  ; optionally, goes before `swm-pomodoro`
+(load-module "swm-pomodoro")
+#+end_src
+
+This enables StumpWM commands:
+- ~pomodoro-start-timer~ starts pomodoro
+- ~pomodoro-cancel-timer~ cancels running pomodoro
+- ~pomodoro-reset~ erases all completed pomodoro's, resets the status.
+- ~pomodoro-status~ prints the status message. Either the pomodoro's running or the type of a break.
+  That's all, folks. Nothing else, not even the time passed/left - you don't need that information,
+  you need concentration! And, by the way, default SBCL timers that are used
+  don't seem to tell you how much time's left anyway...
+
+You may bind these to a *sparse-keymap* as you see fit.
+
+** Notificaitons
+When ~notifications~ stumpwm-contrib module is loaded, the status message
+will also be reflected in the notifications area of the mode-line.
+
+This is checked through ~(asdf:already-loaded-systems)~ so ~notifications~
+need to be loaded prior to ~swm-pomodoro~.
+
+** Sound Signal
+Optionally set ~swm-pomodoro:*bell-sound-file*~ (defaults to "~/Music/bell.wav").
+
+It will be played at each pomodoro's end.
+~swm-pomodoro:*sound-play-command*~ is setf-able too.

--- a/util/pomodoro/package.lisp
+++ b/util/pomodoro/package.lisp
@@ -1,0 +1,117 @@
+;;;; package.lisp
+
+(defpackage #:swm-pomodoro
+  (:use #:cl #:stumpwm)
+  (:export #:*bell-sound-file*
+           #:*sound-play-command*))
+(in-package :swm-pomodoro)
+
+
+(defvar status-message nil
+  "Status message for dashboard, as well as for StumpWM modeline
+when `notifications` are on.")
+
+
+(defvar notifications-loaded
+  (when (member "notifications" (asdf:already-loaded-systems)
+                :test #'string-equal) t)
+  "True when StumpWM-Contrib `Notifications` module is loaded.")
+
+
+(defvar *bell-sound-file* #p"~/Music/bell.wav"
+  "When set to a sound file pathname, that sound will be played
+at the end of each pomodoro.")
+
+
+(defvar *sound-play-command* "aplay"
+  "System command to play sounds.")
+
+
+(defparameter *pomodoro-duration* 1500
+  "Default duration of one pomodoro = 25 * 60 seconds.")
+
+
+(defparameter *pomodoros-scored* 0
+  "Counter of finished pomodoros in a series.")
+
+
+(defun update-status-message ()
+  (when notifications-loaded
+    (notifications:notifications-delete status-message))
+  (setf status-message (timer-status))
+  (when notifications-loaded
+    (notifications:notifications-add status-message)))
+
+
+(defun finish-timer ()
+  "Score Pomodoro."
+  (sb-ext:unschedule-timer *pomodoro-timer*)
+  (incf *pomodoros-scored*)
+  (update-status-message)
+  (stumpwm:message
+   "+1 (`) Pomodoro Scored!~%~a" status-message)
+  (ring-the-bell))
+
+
+(defparameter *pomodoro-timer*
+  (sb-ext:make-timer #'swm-pomodoro::finish-timer
+                     :name :pomodoro-timer))
+
+
+(defun reset-scored ()
+  "Reset finished pomodoros series counter to 0."
+  (setf *pomodoros-scored* 0)
+  (update-status-message))
+
+
+(defun ring-the-bell ()
+  "Play the *BELL-SOUND-FILE* if exists."
+  (when (probe-file *bell-sound-file*)
+    (asdf:run-shell-command
+     "~a ~a" *sound-play-command* (namestring *bell-sound-file*))))
+
+
+(defun notify-break ()
+  "Say what kind of break you deserve."
+  (if (= *pomodoros-scored* 0)
+      "^[^3Work harder!^]"
+      (if (= 0 (mod *pomodoros-scored* 4))
+          "^[^7^B[_])^2 15+ min!^]"
+          "^[^2^B<-> 5 min^]")))
+
+
+(defun many-scored ()
+  "See how many have I scored."
+  (format nil "^[^1^B(`)^6 ~a^]" *pomodoros-scored*))
+
+
+(defun timer-status ()
+  "Print the status of the timer."
+  (if (sb-ext:timer-scheduled-p *pomodoro-timer*)
+      "^[^1^B(`)^n in progress...^]"
+      (format nil "~a : ~a"
+              (many-scored) (notify-break))))
+
+
+(stumpwm:defcommand pomodoro-status () ()
+  (update-status-message)
+  (stumpwm:message status-message))
+
+
+(stumpwm:defcommand pomodoro-reset () ()
+  "Reset global pomodoros series."
+  (reset-scored)
+  (stumpwm:message "Pomodoros series reset."))
+
+
+(stumpwm:defcommand pomodoro-start-timer () ()
+  (when (not (sb-ext:timer-scheduled-p *pomodoro-timer*))
+    (sb-ext:schedule-timer *pomodoro-timer* *pomodoro-duration*)
+    (stumpwm:message "Pomodoro timer set."))
+  (update-status-message))
+
+
+(stumpwm:defcommand pomodoro-cancel-timer () ()
+  (sb-ext:unschedule-timer *pomodoro-timer*)
+  (stumpwm:message "^1(7)^n Pomodoro timer cancelled!")
+  (update-status-message))

--- a/util/pomodoro/swm-pomodoro.asd
+++ b/util/pomodoro/swm-pomodoro.asd
@@ -1,0 +1,11 @@
+;;;; swm-pomodoro.asd
+
+(asdf:defsystem #:swm-pomodoro
+  :description "Pretty basic Pomodoro-tracker for StumpWM."
+  :author "Vladimir (Hawthorne) <vdikan@vivaldi.net>"
+  :license  "GPLv3"
+  :version "0.2.0"
+  :serial t
+  :depends-on (#:stumpwm)
+  :components ((:file "package")
+               (:file "swm-pomodoro")))

--- a/util/pomodoro/swm-pomodoro.lisp
+++ b/util/pomodoro/swm-pomodoro.lisp
@@ -1,0 +1,3 @@
+;;;; swm-pomodoro.lisp
+
+(in-package #:swm-pomodoro)


### PR DESCRIPTION
Reworked my simplistic pomodoro tracker, that I've been using for quite a while, into a contrib util. 
Optionally shows tracker status in the notifications area of stump-tray when `notifications` module is on. 