### PR TITLE
Add hidden window count modeline formatter

### DIFF
--- a/README.org
+++ b/README.org
@@ -77,15 +77,17 @@ Advertise your module here, open a PR and include a org-mode link!
 - [[./media/amixer/README.org][amixer]] :: Manipulate the volume using amixer
 - [[./media/stump-radio/README.org][stump-radio]] :: Minimalistic mplayer-based radio for StumpWM.
 - [[./media/stump-volume-control/README.org][stump-volume-control]] :: Minimalistic amixer-based volume control for StumpWM.
-- [[./media/stumpwm-sndioctl/README.md][stumpwm-sndioctl]] :: Interface to OpenBSD's sndioctl for StumpWM.
+- [[./media/stumpwm-sndioctl/README.org][stumpwm-sndioctl]] :: Interface to OpenBSD's sndioctl from StumpWM.
 ** Minor Modes
 - [[./minor-mode/mpd/README.org][mpd]] :: Displays information about the music player daemon (MPD).
 - [[./minor-mode/notifications/README.org][notifications]] :: A notification library that sends notifications to the modeline via stumpish or from stumpwm itself.
 ** Modeline
 - [[./modeline/battery-portable/README.org][battery-portable]] :: Add battery information to the modeline in a portable way.
 - [[./modeline/bitcoin/README.org][bitcoin]] :: Display bitcoin price on StumpWM modeline.
+- [[./modeline/clim-mode-line/README.org][clim-mode-line]] :: A modeline inspired panel written with CLIM
 - [[./modeline/cpu/README.org][cpu]] :: Add cpu info to the modeline.
 - [[./modeline/disk/README.org][disk]] :: Display filesystem information in the modeline
+- [[./modeline/hidden/README.org][hidden]] :: Add hidden window info to the modeline.
 - [[./modeline/hostname/README.org][hostname]] :: Put hostname in the StumpWM modeline
 - [[./modeline/maildir/README.org][maildir]] :: Display maildir information in the modeline (%M conflicts with mem).
 - [[./modeline/mem/README.org][mem]] :: Display memory in the modeline, %M conflicts with maildir.
@@ -120,6 +122,7 @@ Advertise your module here, open a PR and include a org-mode link!
 - [[./util/searchengines/README.org][searchengines]] :: Allows searching text using prompt or clipboard contents with various search engines
 - [[./util/shell-command-history/README.org][shell-command-history]] :: Save and load the stumpwm::*input-shell-history* to a file
 - [[./util/stump-backlight/README.org][stump-backlight]] :: Native backlight control from StumpWM
+- [[./util/stump-lock/README.org][stump-lock]] :: Screen locker in StumpWM
 - [[./util/stump-nm/README.org][stump-nm]] :: StumpWM integration with NetworkManager
 - [[./util/surfraw/README.org][surfraw]] :: Integrates surfraw with stumpwm.
 - [[./util/swm-emacs/README.org][swm-emacs]] :: A set of utilities for launching the beast.

--- a/modeline/hidden/README.org
+++ b/modeline/hidden/README.org
@@ -1,0 +1,10 @@
+** Usage
+Put:
+#+BEGIN_SRC lisp
+(load-module "hidden")
+#+END_SRC
+In your =~/.stumpwmrc=
+
+Then you can use:
+
+%H (Hidden window count)

--- a/modeline/hidden/hidden.asd
+++ b/modeline/hidden/hidden.asd
@@ -1,0 +1,11 @@
+;;;; hidden.asd
+
+(asdf:defsystem #:hidden
+  :serial t
+  :description "Add hidden window info to the modeline."
+  :author "Woodrow Douglass"
+  :license "GPLv3"
+  :depends-on (#:stumpwm)
+  :components ((:file "package")
+               (:file "hidden")))
+

--- a/modeline/hidden/hidden.lisp
+++ b/modeline/hidden/hidden.lisp
@@ -1,0 +1,28 @@
+;;;; hidden.lisp
+
+(in-package #:hidden)
+
+;;; "hidden" goes here. Hacks and glory await!
+
+;;; Hidden window formatter for the mode-line
+;;;
+;;; Copyright 2021 Woodrow Douglass 
+;;;
+;;; Maintainer: Woodrow Douglass
+;;;
+
+;; Install formatters.
+(add-screen-mode-line-formatter #\H 'hidden-modeline)
+
+(defun hidden-modeline (ml)
+  (declare (ignore ml))
+  (handler-case
+      (progn
+	(if (typep (stumpwm::current-group) 'stumpwm::tile-group)
+	(let ((x (list-length (stumpwm::frame-windows (current-group) (stumpwm::current-frame)))))
+    	  (if (>= x 1)
+    	      (format NIL "(~A Hidden)" (- x 1))
+    	      "(0 Hidden)"))
+            ""))
+    (t (c) (format nil "ERROR: ~A" c))))
+  

--- a/modeline/hidden/package.lisp
+++ b/modeline/hidden/package.lisp
@@ -1,0 +1,5 @@
+;;;; package.lisp
+
+(defpackage #:hidden
+  (:use #:cl :stumpwm))
+


### PR DESCRIPTION
This modeline formatter shows how many windows are hidden behind the current frame in tiling groups.