### PR TITLE
Allow the cpu plugin to show a range of frequencies

### DIFF
--- a/modeline/cpu/package.lisp
+++ b/modeline/cpu/package.lisp
@@ -1,5 +1,7 @@
 ;;;; package.lisp
 
 (defpackage #:cpu
-  (:use #:cl :stumpwm))
+  (:use #:cl :stumpwm)
+  (:export #:*cpu-modeline-fmt*
+	   #:*acpi-thermal-zone*))
 


### PR DESCRIPTION
Default behavior still just shows the frequency of cpu 0, modify `cpu:*cpu-modeline-fmt*` to enable the range

