### PR TITLE
Fix backlight to work with new CLX api (Issue: #228)

### DIFF
--- a/util/stump-backlight/backlight.lisp
+++ b/util/stump-backlight/backlight.lisp
@@ -41,7 +41,7 @@
        (vector (scaled-current output (1+ min) (1- max))) ; max is non-inclusive
                                                           ; in X11 API, but
                                                           ; inclusive in ours.
-       backlight-type))))
+       :atom-type backlight-type))))
 
 (defun scaled-current (output min max)
   (truncate (/ (* (gethash output *current-percent*) (- max min)) 100)))


### PR DESCRIPTION
From https://github.com/stumpwm/stumpwm-contrib/issues/228

Backlight module was broken With CLX stemming from this commit
https://github.com/sharplispers/clx/commit/8e071554a5531988d21f088953de7b741c2b2980

```
Although this commit introduces two backwards-incompatible changes, they
should (hopefully) not be too inconvenient because this extension is as
yet unfinished and thus unsuitable for general use. The first, and more
important, change is the replacement of optional arguments with keyword
arguments in all request functions having optional arguments, which
affects only those callers who were supplying any optional arguments.
```

Calling backlight-increase or backlight-decrease would
result in error: "Error in Command 'backlight-increase': odd number of
&KEY arguments"

# Checklist when contributing a new contrib

- [N/A] Have you run `./update-readme.sh`?
