### PR TITLE
get correct thermal zone for cpu temp

### DIFF
--- a/modeline/cpu/cpu.lisp
+++ b/modeline/cpu/cpu.lisp
@@ -111,7 +111,8 @@ utilization."
         (sys-dir (sort
                   (remove-if-not
                    (lambda (x)
-                     (when (cl-ppcre:scan "^.*/thermal_zone\\d+/" (namestring x))
+                     (when (and (cl-ppcre:scan "^.*/thermal_zone\\d+/" (namestring x))
+                                (string-equal (alexandria:read-file-into-string (format nil "~A/type" x)) (format nil "x86_pkg_temp~%")))
                        x))
                    (list-directory #P"/sys/class/thermal/"))
                   #'string< :key #'namestring)))


### PR DESCRIPTION
Use thermal zone with type `x86_pkg_temp` to fetch the cpu temperature.