### PR TITLE
Add stumpwm-dmenu third party module

### DIFF
--- a/README.org
+++ b/README.org
@@ -68,6 +68,7 @@ Please see =README.org= files for each module for further details. Missing modul
 * Third Party Modules
 Advertise your module here, open a PR and include a org-mode link!
 - [[https://github.com/njkli/stumpwm-weather/blob/master/readme.org][stumpwm-weather]] :: Displays weather in the modeline
+- [[https://gitlab.com/sasanidas/stumpwm-dmenu][stumpwm-dmenu]]   :: StumpWM [[https://tools.suckless.org/dmenu/][dmenu]] integration
 * Current Modules
 (click for its respective README/docs)
 


### PR DESCRIPTION
Add dmenu stumpwm integration as a thir party module.

It's base on [stumpwm-dmenu-wrapper](https://github.com/horellana/stumpwm-dmenu-wrapper) but with multiple screen/group support and .asd integration.