### PR TITLE
Removed non existent command binwarp-down in binwarp.lisp

### DIFF
--- a/util/binwarp/binwarp.lisp
+++ b/util/binwarp/binwarp.lisp
@@ -104,7 +104,7 @@ moves the pointer to the center of this area -- in the direction of the GRAVITY.
 (defvar *default-binwarp-keymap*
   '(((stumpwm:kbd "Down") "binwarp down")
     ((stumpwm:kbd "n") "binwarp down")
-    ((stumpwm:kbd "j") "binwarp-down")
+    ((stumpwm:kbd "j") "binwarp down")
 
     ((stumpwm:kbd "Up") "binwarp up")
     ((stumpwm:kbd "p") "binwarp up")


### PR DESCRIPTION
Pretty straight forward fix to hitting `j` in binwarp-mode caused the error `Command 'binwarp-down' not found`. This was due to the command `binwarp down` was misspelled as `binwarp-down`