### PR TITLE
Escape any caret chars in clipboard entry display strings

### DIFF
--- a/util/clipboard-history/clipboard-history.lisp
+++ b/util/clipboard-history/clipboard-history.lisp
@@ -49,7 +49,7 @@
                   (stumpwm:select-from-menu
                    (stumpwm:current-screen)
                    (mapcar (lambda (s)
-                             (list (string-maxlen s 32) s))
+                             (list (stumpwm::escape-caret (string-maxlen s 32)) s))
                            *clipboard-history*)
                    nil))))
         (when sel


### PR DESCRIPTION
# Checklist when contributing a new contrib

- [X] Have you run `./update-readme.sh`?

This PR fixes an exception which is thrown when viewing a menu of clipboard entries which contain caret (`^`) characters. This collides with the embedded color string sequence support in StumpWM. The fix is to escape such caret characters using `stumpwm::escape-caret`