### PR TITLE
Fixed pomodoro and alert timers

### DIFF
--- a/util/alert-me/alert-me.asd
+++ b/util/alert-me/alert-me.asd
@@ -3,6 +3,6 @@
   :description "Alert me that an event is coming"
   :author "Florian Margaine <florian@margaine.com>"
   :license "GPLv3"
-  :depends-on (:bordeaux-threads :stumpwm)
+  :depends-on (:uiop :bordeaux-threads :stumpwm :notifications)
   :components ((:file "package")
                (:file "alert-me")))

--- a/util/alert-me/alert-me.lisp
+++ b/util/alert-me/alert-me.lisp
@@ -1,22 +1,61 @@
 (in-package #:alert-me)
 
-(stumpwm:defcommand alert-me-at (alert-hour alert-minute message) ((:number "hour: ") (:number "minute: ") (:string "message: "))
+
+(defvar *alert-sound-file* #p"~/Music/bell.wav"
+        "When set to a sound file pathname, plays on alert.")
+
+
+(defvar *sound-play-command* "aplay"
+  "System command to play sounds.")
+
+
+(defvar notifications-loaded
+  (when (member "notifications" (asdf:already-loaded-systems)
+                :test #'string-equal) t)
+  "True when StumpWM-Contrib `Notifications` module is loaded.")
+
+
+(defun ring-alert ()
+  "Play the *ALERT-SOUND-FILE* if exists."
+  (when (probe-file *alert-sound-file*)
+    (asdf:run-shell-command
+     "~a ~a" *sound-play-command* (namestring *alert-sound-file*))))
+
+
+(defun alert-message (alert-hour alert-minute message)
+  (format nil "^[^3 ~2,'0d:~2,'0d ^2~a ^]"
+          alert-hour alert-minute message))
+
+
+(stumpwm:defcommand alert-me-at (alert-hour alert-minute message)
+    ((:number "hour: ") (:number "minute: ") (:string "message: "))
   "Alert me at some point in time."
   (unless (validate-alert alert-hour alert-minute message)
     (error "One of the parameters is either empty or wrong."))
   (bordeaux-threads:make-thread
    #'(lambda ()
+       (stumpwm:message "Alert is set: ~a"
+                        (alert-message alert-hour alert-minute message))
        (loop
-          do (sleep 5)
-          when (multiple-value-bind (seconds minute hour)
-                   (get-decoded-time)
-                 (declare (ignore seconds))
-                 (and (= alert-hour hour) (= alert-minute minute)))
-          do (repeat-with-delay 10 3
-               #'(lambda (count)
-                   (stumpwm:message "The time for ~A is now! (~D/3 remainder)"
-                                    message (1+ count))))))
+         do (sleep 5)
+         when (multiple-value-bind (seconds minute hour)
+                  (get-decoded-time)
+                (declare (ignore seconds))
+                (and (= alert-hour hour) (= alert-minute minute)))
+           do (progn
+                (when notifications-loaded
+                  (notifications:notifications-add
+                   (alert-message alert-hour alert-minute message)))
+                (repeat-with-delay
+                 10 3
+                 #'(lambda (count)
+                     (stumpwm:message "~a ^[^4[^1 ~d/3 ^4] ^]"
+                                      (alert-message alert-hour alert-minute message)
+                                      (1+ count))
+                     (ring-alert)))
+                (return))))
    :name (format nil "Alert thread: ~A" message)))
+
 
 (defun validate-alert (alert-hour alert-minute message)
   (unless (or alert-hour alert-minute message)
@@ -24,11 +63,12 @@
   (multiple-value-bind (seconds minute hour)
       (get-decoded-time)
     (declare (ignore seconds))
-    (when (> hour alert-hour)
-      (return-from validate-alert nil))
-    (when (>= minute alert-minute)
+    (when (or (> hour alert-hour)
+              (and (= hour alert-hour)
+                   (>= minute alert-minute)))
       (return-from validate-alert nil)))
   t)
+
 
 (defun repeat-with-delay (delay times fn)
   (dotimes (i times)

--- a/util/alert-me/alert-me.lisp
+++ b/util/alert-me/alert-me.lisp
@@ -18,7 +18,7 @@
 (defun ring-alert ()
   "Play the *ALERT-SOUND-FILE* if exists."
   (when (probe-file *alert-sound-file*)
-    (asdf:run-shell-command
+    (uiop:run-program
      "~a ~a" *sound-play-command* (namestring *alert-sound-file*))))
 
 

--- a/util/pomodoro/package.lisp
+++ b/util/pomodoro/package.lisp
@@ -35,6 +35,10 @@ at the end of each pomodoro.")
   "Counter of finished pomodoros in a series.")
 
 
+(defparameter *pomodoro-timer* nil
+  "The pomodoro timer clock object.")
+
+
 (defun update-status-message ()
   (when notifications-loaded
     (notifications:notifications-delete status-message))
@@ -53,7 +57,7 @@ at the end of each pomodoro.")
   (ring-the-bell))
 
 
-(defparameter *pomodoro-timer*
+(setf *pomodoro-timer*
   (sb-ext:make-timer #'swm-pomodoro::finish-timer
                      :name :pomodoro-timer))
 
@@ -67,7 +71,7 @@ at the end of each pomodoro.")
 (defun ring-the-bell ()
   "Play the *BELL-SOUND-FILE* if exists."
   (when (probe-file *bell-sound-file*)
-    (asdf:run-shell-command
+    (uiop:run-program
      "~a ~a" *sound-play-command* (namestring *bell-sound-file*))))
 
 

--- a/util/pomodoro/swm-pomodoro.asd
+++ b/util/pomodoro/swm-pomodoro.asd
@@ -6,6 +6,6 @@
   :license  "GPLv3"
   :version "0.2.0"
   :serial t
-  :depends-on (#:stumpwm)
+  :depends-on (#:uiop #:stumpwm #:notifications)
   :components ((:file "package")
                (:file "swm-pomodoro")))


### PR DESCRIPTION
Fixed bug in `alert-me`. Tweaked `alert-me` and `pomodoro`, they compile ok with ASDF.