### PR TITLE
Use the correct way to set the variable in README for the productivity module

### DIFF
--- a/util/productivity/README.org
+++ b/util/productivity/README.org
@@ -44,7 +44,7 @@ the code.
     =*top-map*= and their associated commands.
 ex:
 #+BEGIN_SRC lisp
-    (setf *productivity-keys*
+    (setf productivity::*productivity-keys*
           '(("H-t"   *root-map*)
             ("C-;"   *rat-map*)
             ("Print" "screenshot")))


### PR DESCRIPTION
I don't know much about Common Lisp but without this, `productivity` mode wouldn't pick up the variable that was set in my init file, I found this StackOverflow post that says that two colons should be put before an unexported variable: https://stackoverflow.com/questions/8567155/why-colons-precede-variables-in-common-lisp

And my problem was solved.