### PR TITLE
fix sndioctl typo that breaks loading

### DIFF
--- a/media/stumpwm-sndioctl/stumpwm-sndioctl.asd
+++ b/media/stumpwm-sndioctl/stumpwm-sndioctl.asd
@@ -19,7 +19,7 @@
 (asdf:defsystem #:stumpwm-sndioctl
   :description "Interface to OpenBSD's sndioctl from StumpWM."
   :author "Dr Ashton Fagg <ashton@fagg.id.au>"
-  :license  "ISC""
+  :license  "ISC"
   :version "0.0.1"
   :homepage "https://github.com/fagg/stumpwm-sndioctl"
   :serial t


### PR DESCRIPTION
Tiny quoting typo in the sndioctl module that was causing issues with loading it.

# Checklist when contributing a new contrib

- [X] Have you run `./update-readme.sh`?
