### PR TITLE
case-insensitive swm-ssh config parsing

### DIFF
--- a/util/swm-ssh/swm-ssh.lisp
+++ b/util/swm-ssh/swm-ssh.lisp
@@ -10,7 +10,7 @@
 
 (defvar *swm-ssh-config-path* #p"~/.ssh/config")
 
-(defvar *host-regex* "^Host[ \t]+")
+(defvar *host-regex* "^(?i)Host[ \t]+")
 
 (defvar *swm-ssh-default-term* "urxvtc")
 


### PR DESCRIPTION
The SSH config file's keywords are case-insensitive, so I changed the swm-ssh module's regex accordingly since it wasn't working with my config.

# Checklist when contributing a new contrib

- [X] Have you run `./update-readme.sh`?
