### PR TITLE
miniscule compatibility improvement to end-session

### DIFF
--- a/util/end-session/README.org
+++ b/util/end-session/README.org
@@ -3,7 +3,7 @@
    and shutdown or reboot the computer. A logout command is also
    provided.
 
-   This module requires the use of =systemD=, and requires the =polkit=
+   This module requires the use of =logind= (or elogind), and requires the =polkit=
    package to be installed, as well as the =wmctl= command.
 ** Usage
    Add these lines to your =.stumprc= file:

--- a/util/end-session/end-session.lisp
+++ b/util/end-session/end-session.lisp
@@ -42,7 +42,7 @@ Returns true when yes is selected"
   (let ((choice (yes-no-diag "Really suspend?")))
     (when choice
       (echo-string (current-screen) "Suspending...")
-      (run-shell-command "systemctl suspend"))))
+      (run-shell-command "loginctl suspend"))))
 
 (defun close-all-apps ()
   "Closes all windows managed by stumpwm gracefully"
@@ -57,7 +57,7 @@ Returns true when yes is selected"
       (echo-string (current-screen) "Shutting down...")
       (close-all-apps)
       (run-hook *quit-hook*)
-      (run-shell-command "systemctl poweroff"))))
+      (run-shell-command "loginctl poweroff"))))
 
 ;; can't name the function "restart"
 (defcommand restart-computer () ()
@@ -66,7 +66,7 @@ Returns true when yes is selected"
       (echo-string (current-screen) "Restarting...")
       (close-all-apps)
       (run-hook *quit-hook*)
-      (run-shell-command "systemctl reboot"))))
+      (run-shell-command "loginctl reboot"))))
 
 (defcommand logout () ()
   (let ((choice (yes-no-diag "Close all programs and quit stumpwm?")))


### PR DESCRIPTION
honestly not sure why systemctl was used to begin with, loginctl has slightly better compatibility since it also works with elogind

a very petty change, but since its literally a matter of 3 words with no drawbacks, i just don't see a reason not to at least try