### PR TITLE
Recognize battery state "Not charging" as :charged

### DIFF
--- a/modeline/battery-portable/battery-portable.lisp
+++ b/modeline/battery-portable/battery-portable.lisp
@@ -228,7 +228,9 @@
                              (state (or (and (stringp state)
                                              (cond ((string= state "Charging") :charging)
                                                    ((string= state "Discharging") :discharging)
-                                                   ((string= state "Full") :charged)
+                                                   ((or (string= state "Full")
+                                                        (string= state "Not charging"))
+                                                    :charged)
                                                    (t :unknown)))
                                         :unknown)))
                         (values state


### PR DESCRIPTION
On my laptop, acpi shows:

$ acpi
Battery 0: Not charging, 99%

Within the battery-portable module, (sysfs-field path "status") reports this as "Not charging".

In order to let the battery not be in an :unknown state, this change allows "Not charging" to be recognized as :charging in addition to "Full".

# Checklist when contributing a new contrib

- [ ] Have you run `./update-readme.sh`?
