### PR TITLE
Allow more user configuration in the wifi and end-session modules

### DIFF
--- a/modeline/wifi/package.lisp
+++ b/modeline/wifi/package.lisp
@@ -5,5 +5,6 @@
   (:export #:*iwconfig-path*
            #:*wireless-device*
            #:*wifi-modeline-fmt*
+           #:*wifi-signal-quality-fmt*
+           #:*wifi-signal-quality-fmt-pc*
            #:*use-colors*))
-

--- a/modeline/wifi/wifi.lisp
+++ b/modeline/wifi/wifi.lisp
@@ -33,6 +33,12 @@ Signal quality (without percentage sign)
 @end table
 ")
 
+(defvar *wifi-signal-quality-fmt* "^[~A~D^]"
+  "The default formatting of the signal quality")
+
+(defvar *wifi-signal-quality-fmt-pc* "^[~A~D%^]"
+  "The default formatting of the signal quality as percentage")
+
 (defvar *use-colors* t
   "Use colors to indicate signal quality.")
 
@@ -47,11 +53,11 @@ Signal quality (without percentage sign)
 
 (defun wifi-get-signal-quality-pc (pair)
   (let ((qual (cdr pair)))
-    (format nil "^[~A~D%^]" (sig-quality-fmt qual) qual)))
+    (format nil *wifi-signal-quality-fmt-pc* (sig-quality-fmt qual) qual)))
 
 (defun wifi-get-signal-quality (pair)
   (let ((qual (cdr pair)))
-    (format nil "^[~A~D^]" (sig-quality-fmt qual) qual)))
+    (format nil *wifi-signal-quality-fmt* (sig-quality-fmt qual) qual)))
 
 (defvar *wifi-formatters-alist*
   '((#\e wifi-get-essid)

--- a/util/end-session/README.org
+++ b/util/end-session/README.org
@@ -12,6 +12,8 @@
      (add-to-load-path #p"path-to-contrib/util/end-session")
      ;; actually load the module
      (load-module "end-session")
+     ;; Use loginctl instead of the default systemctl
+     (setf end-session:*end-session-command* "loginctl")
    #+END_SRC
 *** Commands Provided:
   - =end-session= Prompts for shutdown, restart, or logoff. You can

--- a/util/end-session/README.org
+++ b/util/end-session/README.org
@@ -4,7 +4,7 @@
    provided.
 
    This module requires the use of =logind= (or elogind), and requires the =polkit=
-   package to be installed, as well as the =wmctl= command.
+   package to be installed, as well as the =wmctrl= command.
 ** Usage
    Add these lines to your =.stumprc= file:
    #+BEGIN_SRC lisp
@@ -15,7 +15,7 @@
    #+END_SRC
 *** Commands Provided:
   - =end-session= Prompts for shutdown, restart, or logoff. You can
-     customize what this shows with =*end-session-menu*=. See [[file:session-ending.lisp::77]]
+     customize what this shows with =*end-session-menu*=. See [[file:end-session.lisp::86]]
   - shutdown-computer
   - restart-computer
   - logout

--- a/util/end-session/end-session.lisp
+++ b/util/end-session/end-session.lisp
@@ -28,7 +28,7 @@
 ;;; DEALINGS IN THE SOFTWARE.
 ;;;
 
-(defvar *base-command* "systemctl")
+(defvar *end-session-command* "systemctl")
 
 (defun yes-no-diag (query-string)
   "Presents a yes-no dialog to the user asking query-string.
@@ -43,7 +43,7 @@ Returns true when yes is selected"
   (let ((choice (yes-no-diag "Really suspend?")))
     (when choice
       (echo-string (current-screen) "Suspending...")
-      (run-shell-command (concat *base-command* " suspend")))))
+      (run-shell-command (concat *end-session-command* " suspend")))))
 
 (defun close-all-apps ()
   "Closes all windows managed by stumpwm gracefully"
@@ -58,7 +58,7 @@ Returns true when yes is selected"
       (echo-string (current-screen) "Shutting down...")
       (close-all-apps)
       (run-hook *quit-hook*)
-      (run-shell-command (concat *base-command* " poweroff")))))
+      (run-shell-command (concat *end-session-command* " poweroff")))))
 
 ;; can't name the function "restart"
 (defcommand restart-computer () ()
@@ -67,7 +67,7 @@ Returns true when yes is selected"
       (echo-string (current-screen) "Restarting...")
       (close-all-apps)
       (run-hook *quit-hook*)
-      (run-shell-command (concat *base-command* " reboot")))))
+      (run-shell-command (concat *end-session-command* " reboot")))))
 
 (defcommand logout () ()
   (let ((choice (yes-no-diag "Close all programs and quit stumpwm?")))

--- a/util/end-session/end-session.lisp
+++ b/util/end-session/end-session.lisp
@@ -28,6 +28,7 @@
 ;;; DEALINGS IN THE SOFTWARE.
 ;;;
 
+(defvar *base-command* "systemctl")
 
 (defun yes-no-diag (query-string)
   "Presents a yes-no dialog to the user asking query-string.
@@ -42,7 +43,7 @@ Returns true when yes is selected"
   (let ((choice (yes-no-diag "Really suspend?")))
     (when choice
       (echo-string (current-screen) "Suspending...")
-      (run-shell-command "loginctl suspend"))))
+      (run-shell-command (concat *base-command* " suspend")))))
 
 (defun close-all-apps ()
   "Closes all windows managed by stumpwm gracefully"
@@ -57,7 +58,7 @@ Returns true when yes is selected"
       (echo-string (current-screen) "Shutting down...")
       (close-all-apps)
       (run-hook *quit-hook*)
-      (run-shell-command "loginctl poweroff"))))
+      (run-shell-command (concat *base-command* " poweroff")))))
 
 ;; can't name the function "restart"
 (defcommand restart-computer () ()
@@ -66,7 +67,7 @@ Returns true when yes is selected"
       (echo-string (current-screen) "Restarting...")
       (close-all-apps)
       (run-hook *quit-hook*)
-      (run-shell-command "loginctl reboot"))))
+      (run-shell-command (concat *base-command* " reboot")))))
 
 (defcommand logout () ()
   (let ((choice (yes-no-diag "Close all programs and quit stumpwm?")))

--- a/util/end-session/package.lisp
+++ b/util/end-session/package.lisp
@@ -2,4 +2,4 @@
 
 (defpackage #:end-session
   (:use #:cl :stumpwm)
-  (:export #:*base-command*))
+  (:export #:*end-session-command*))

--- a/util/end-session/package.lisp
+++ b/util/end-session/package.lisp
@@ -1,4 +1,5 @@
 ;;;; package.lisp
 
 (defpackage #:end-session
-  (:use #:cl :stumpwm))
+  (:use #:cl :stumpwm)
+  (:export #:*base-command*))


### PR DESCRIPTION
# Wifi
Allow users to configure how the signal quality is formatted instead of having it hardcoded.

# End-session
Allow users to configure whether to use `systemctl` or `loginctl`, this is in response to the changes in pull request #259.
 
# Checklist when contributing a new contrib

- [ x] Have you run `./update-readme.sh`?
