### PR TITLE
Use bash at stumpish

### DIFF
--- a/util/stumpish/stumpish
+++ b/util/stumpish/stumpish
@@ -180,7 +180,7 @@ else
         tput me sgr0
         echo \ for a list of commands.
 
-	while read -p '> ' REPLY
+	while (echo -n '> '; read -r REPLY)
 	do
 	    tput md bold
 	    tput AF setaf 2


### PR DESCRIPTION
`stumpish` depends on bash by using `read -p` for example, so it hasn't got any chance to ran well on anything else.

And `/bin/sh` not always bash, it might be something very limited.
