### PR TITLE
Use known_hosts as source at swm-ssh

### DIFF
--- a/util/swm-ssh/README.org
+++ b/util/swm-ssh/README.org
@@ -31,8 +31,9 @@ Default terminal to open an ssh connection is ~urxvtc~. To change it, use
 (setq swm-ssh:*swm-ssh-default-term* "xterm")
 #+END_SRC
 
-** *swm-ssh-config-path*
-Ssh config file path. Defaults to =~/.ssh/config=. Change it with
+** *swm-ssh-known-host-path*
+Path to thee list of know host bz SSH client. Defaults to =~/.ssh/known_hosts=.
+Change it with
 #+BEGIN_SRC lisp
-(setq swm-ssh:*swm-ssh-config-path* "/path/to/ssh/config")
+(setq swm-ssh:*swm-ssh-known-hosts-path* "/path/to/ssh/known_hosts")
 #+END_SRC

--- a/util/swm-ssh/swm-ssh.lisp
+++ b/util/swm-ssh/swm-ssh.lisp
@@ -3,29 +3,31 @@
 (defpackage #:swm-ssh
   (:use #:cl #:stumpwm)
   (:export #:*swm-ssh-default-term*
-           #:*swm-ssh-config-path*)
+           #:*swm-ssh-known-hosts-path*)
   (:import-from #:cl-ppcre))
 
 (in-package #:swm-ssh)
 
-(defvar *swm-ssh-config-path* #p"~/.ssh/config")
+(defvar *swm-ssh-known-hosts-path* #p"~/.ssh/known_hosts")
 
-(defvar *host-regex* "^(?i)Host[ \t]+")
+(defvar *host-regex* "^([^ :]+)( |\\t).+")
 
 (defvar *swm-ssh-default-term* "urxvtc")
 
-(defun collect-hosts (&optional (ssh-config *swm-ssh-config-path*))
-  (with-open-file (stream ssh-config :direction :input)
+(defun collect-hosts (&optional (ssh-known-hosts *swm-ssh-known-hosts-path*))
+  (with-open-file (stream ssh-known-hosts :direction :input)
     (loop for line = (read-line stream nil)
           while line
           when (cl-ppcre:scan *host-regex* line)
-            collect (cl-ppcre:regex-replace-all *host-regex* line ""))))
+            collect (cl-ppcre:regex-replace-all *host-regex* line "\\1"))))
 
 (stumpwm:defcommand swm-ssh-menu () ()
   "Select a host to ssh to"
   (let ((entry (stumpwm:select-from-menu
                 (stumpwm:current-screen)
-                (mapcar 'list (collect-hosts))
+                (mapcar 'list
+                        (delete-duplicates (collect-hosts)
+                                           :test #'equal))
                 "Open ssh connection to: ")))
     (when entry
       (stumpwm:run-shell-command (format nil "~A -e ssh ~A" *swm-ssh-default-term* (car entry))))))


### PR DESCRIPTION
Unfortently, config may contains wildcard based domains which makes it usless for this module, but from another hand the known_hosts is good source for known connections.

Thus, tramp uses the same idea.
