### PR TITLE
Allow to use doas to run sndioctl

### DIFF
--- a/media/stumpwm-sndioctl/package.lisp
+++ b/media/stumpwm-sndioctl/package.lisp
@@ -20,6 +20,7 @@
   (:use #:cl #:stumpwm)
   (:export #:*terse*
 	   #:*step*
+	   #:*doas*
 	   #:volume-up
 	   #:volume-down
 	   #:toggle-mute

--- a/media/stumpwm-sndioctl/stumpwm-sndioctl.lisp
+++ b/media/stumpwm-sndioctl/stumpwm-sndioctl.lisp
@@ -22,10 +22,13 @@
 
 (defvar *step* 0.05)
 (defvar *terse* nil "If t, this will supress messages that get shown on changes to volume.")
+(defvar *doas* nil "If t, this will use doas to run sndioctl.")
 
 (defun call-sndioctl (args captive)
   "Calls sndioctl with the required arguments."
-  (run-shell-command (format nil "sndioctl ~a" args) captive))
+  (run-shell-command
+   (format nil "~asndioctl ~a" (if *doas* "doas " "") args)
+   captive))
 
 (defun make-step-cmd (direction)
   "Helpful wrapper for generating command strings for incrementing/decrementing volume."


### PR DESCRIPTION
When another user stream something like mpd, sndioctl can't increase or decrease volume when is runned from non root user.

Here I've added a simple way to enforce doas which is an equiualent for sudo for OpenBSD -- the only platform where sndioctl exists.

# Checklist when contributing a new contrib

- [ ] Have you run `./update-readme.sh`?
