### PR TITLE
Pinentry: increase stability

### DIFF
--- a/util/pinentry/pinentry.lisp
+++ b/util/pinentry/pinentry.lisp
@@ -6,10 +6,12 @@
 (defun main (stream)
   (let ((description (percent:decode (read-line stream)))
         (prompt (read-line stream)))
-    (format stream (or (stumpwm:read-one-line (stumpwm:current-screen)
-                                              (format nil "~a~%~a " description prompt)
-                                              :password t)
-                       ""))))
+    (format stream
+            (percent:encode
+             (or (stumpwm:read-one-line (stumpwm:current-screen)
+                                               (format nil "~a~%~a " description prompt)
+                                               :password t)
+                        "")))))
 
 (handler-case (usocket:socket-server "127.0.0.1" 22222 #'main nil
                         :in-new-thread t

--- a/util/pinentry/pinentry.lisp
+++ b/util/pinentry/pinentry.lisp
@@ -4,14 +4,15 @@
 (in-package #:pinentry)
 
 (defun main (stream)
-  (let ((description (percent:decode (read-line stream)))
-        (prompt (read-line stream)))
-    (format stream
-            (percent:encode
-             (or (stumpwm:read-one-line (stumpwm:current-screen)
-                                               (format nil "~a~%~a " description prompt)
-                                               :password t)
-                        "")))))
+  (ignore-errors
+   (let ((description (percent:decode (read-line stream)))
+         (prompt (read-line stream)))
+     (format stream
+             (percent:encode
+              (or (stumpwm:read-one-line (stumpwm:current-screen)
+                                         (format nil "~a~%~a " description prompt)
+                                         :password t)
+                  ""))))))
 
 (handler-case (usocket:socket-server "127.0.0.1" 22222 #'main nil
                         :in-new-thread t


### PR DESCRIPTION
Here two changes which dramatically increase stability.

Before this and https://github.com/stumpwm/stumpwm-contrib/pull/287 my stumpwm crashes on entering PIN quite often.

After this two PRs I can't crash it anymore.