### PR TITLE
Move pinentry to stumpish

### DIFF
--- a/util/pinentry/pinentry.lisp
+++ b/util/pinentry/pinentry.lisp
@@ -1,22 +1,15 @@
 (defpackage #:pinentry
-  (:use #:cl))
+  (:use #:cl)
+  (:export #:getpin))
 
 (in-package #:pinentry)
 
-(defun main (stream)
+(defun getpin (description prompt)
   (ignore-errors
-   (let ((description (percent:decode (read-line stream)))
-         (prompt (read-line stream)))
-     (format stream
-             (percent:encode
-              (or (stumpwm:read-one-line (stumpwm:current-screen)
-                                         (format nil "~a~%~a " description prompt)
-                                         :password t)
-                  ""))))))
-
-(handler-case (usocket:socket-server "127.0.0.1" 22222 #'main nil
-                        :in-new-thread t
-                        :multi-threading t)
-  ;; Probably already running:
-  (usocket:address-in-use-error ())
-  (usocket:address-not-available-error ()))
+   (let ((description (percent:decode description))
+         (prompt (percent:decode prompt)))
+     (percent:encode
+      (or (stumpwm:read-one-line (stumpwm:current-screen)
+                                 (format nil "~a~%~a " description prompt)
+                                 :password t)
+          "")))))

--- a/util/pinentry/stumpwm-pinentry
+++ b/util/pinentry/stumpwm-pinentry
@@ -12,7 +12,7 @@ while IFS="\n" read -r command; do
     elif [[ "$command" == SETPROMPT* ]]; then
         prompt=${command:10}
     elif [ "$command" == GETPIN ]; then
-        password=$(printf "%s\n%s\n" "$description" "$prompt" | nc 127.0.0.1 22222)
+        password=$(stumpish eval "(pinentry:getpin \"$description\" \"$prompt\")" | cut -d '""' -f 2)
         if [ -z "$password" ]; then
             echo S close_button
         fi

--- a/util/pinentry/stumpwm-pinentry
+++ b/util/pinentry/stumpwm-pinentry
@@ -13,6 +13,9 @@ while IFS="\n" read -r command; do
         prompt=${command:10}
     elif [ "$command" == GETPIN ]; then
         password=$(printf "%s\n%s\n" "$description" "$prompt" | nc 127.0.0.1 22222)
+        if [ -z "$password" ]; then
+            echo S close_button
+        fi
         echo D "$password"
     elif [ "$command" == BYE ]; then
         exit 0


### PR DESCRIPTION
Instead using nc and dedicated thread which lock current screen, use stumpish to run the function.

It is a bit slower, but way stable than old way.

It includes https://github.com/stumpwm/stumpwm-contrib/pull/287 and https://github.com/stumpwm/stumpwm-contrib/pull/288