### PR TITLE
Use ssh hostname in window title, instead just ssh

### DIFF
--- a/util/swm-ssh/swm-ssh.lisp
+++ b/util/swm-ssh/swm-ssh.lisp
@@ -30,4 +30,6 @@
                                            :test #'equal))
                 "Open ssh connection to: ")))
     (when entry
-      (stumpwm:run-shell-command (format nil "~A -e ssh ~A" *swm-ssh-default-term* (car entry))))))
+      (let ((host (car entry)))
+        (stumpwm:run-shell-command
+         (format nil "~A -T ~A -e ssh ~A" *swm-ssh-default-term* host host))))))


### PR DESCRIPTION
`-T` seems universal way to setup title which works on both xterm and urxvt
