### PR TITLE
stumptray: Adjust icon vertical and horizontal spacing

### DIFF
--- a/modeline/stumptray/package.lisp
+++ b/modeline/stumptray/package.lisp
@@ -5,6 +5,7 @@
   (:export *tray-viwin-background*
            *tray-hiwin-background*
            *tray-placeholder-pixels-per-space*
+	   *tray-icon-spacing*
 
            add-mode-line-hooks
            remove-mode-line-hooks

--- a/modeline/stumptray/stumptray.lisp
+++ b/modeline/stumptray/stumptray.lisp
@@ -65,6 +65,8 @@ first on the list by default.")
 ;;; stumpwm there is a modeline for every X screen.
 (defvar *tray-cursor-thickness* 2)
 (defvar *tray-cursor-icon-distance* 1)
+(defparameter *tray-icon-spacing* 10
+  "The number of pixels between each icon")
 
 (defun trayicon-height (tray)
   "Returns the height of the icons embedded in the TRAY."
@@ -133,7 +135,9 @@ window coordinates.")
 	 (tray-height (screen-tray-height screen))
 	 (win (xlib:create-window :parent parent
                                   :x x
-                                  :y y
+                                  :y (if (= y 0)
+					 (setf y (floor (/ (- tray-height icon-height) 2)))
+					 y)
                                   :depth depth
                                   :width icon-height
                                   :height tray-height
@@ -306,7 +310,7 @@ protocol."
   (let ((x 0))
     (dolist (icon icons)
       (setf (xlib:drawable-x icon) x)
-      (incf x (xlib:drawable-width icon)))))
+      (incf x (+ (xlib:drawable-width icon) *tray-icon-spacing*)))))
 
 (defun tray-tile-icons (tray)
   "Repositions the icons embedded in TRAY one next to the other."
@@ -350,7 +354,8 @@ protocol."
   "Returns the width of the appropriate TRAY icon container
 based on VISIBILITY."
   (max (trayicon-height tray)
-       (reduce #'+ (tray-icons tray visibility) :key #'xlib:drawable-width)))
+       (+ (* *tray-icon-spacing* (length (tray-icons tray visibility)))
+	  (reduce #'+ (tray-icons tray visibility) :key #'xlib:drawable-width))))
 
 (defun update-icon-containers-geometry (tray)
   "Appropriately resizes the TRAY's icon containers (visible and hidden icons)."


### PR DESCRIPTION
I found that stumptray drew images too close to each other, so I fixed that by adding an exported parameter *tray-icon-spacing* to set the icon spacing. I also added some logic behind the default y positioning so that it's not drawn on the little rectangle that stumpwm draws around the mode-line. It's now drawn in the middle of the mode-line.

Before:
![before](https://github.com/user-attachments/assets/6ffca9af-2ac7-4e32-afcf-d0199ebed841)

After:
![after](https://github.com/user-attachments/assets/067b59c1-8363-4c6b-89c0-17889abbfdef)

The spacing can be modified by doing

```lisp
(setf stumptray:*tray-icon-spacing* 1)
```

In init.lisp.