### PR TITLE
Introduce `*swm-ssh-default-term-title-opt*`

### DIFF
--- a/util/swm-ssh/README.org
+++ b/util/swm-ssh/README.org
@@ -31,6 +31,14 @@ Default terminal to open an ssh connection is ~urxvtc~. To change it, use
 (setq swm-ssh:*swm-ssh-default-term* "xterm")
 #+END_SRC
 
+** *swm-ssh-default-term-title-opt*
+Default terminal's title option is ~-T~ which is used to setup title to
+a connection host. It works with both ~xterm~ and ~urxvtc~ out of the
+box. ~nil~ disable it. To change it, use
+#+BEGIN_SRC lisp
+(setq swm-ssh:*swm-ssh-default-termt-itle-opt* "--title")
+#+END_SRC
+
 ** *swm-ssh-known-host-path*
 Path to thee list of know host bz SSH client. Defaults to =~/.ssh/known_hosts=.
 Change it with

--- a/util/swm-ssh/swm-ssh.lisp
+++ b/util/swm-ssh/swm-ssh.lisp
@@ -3,6 +3,7 @@
 (defpackage #:swm-ssh
   (:use #:cl #:stumpwm)
   (:export #:*swm-ssh-default-term*
+           #:*swm-ssh-default-term-title-opt*
            #:*swm-ssh-known-hosts-path*)
   (:import-from #:cl-ppcre))
 
@@ -13,6 +14,8 @@
 (defvar *host-regex* "^([^ :]+)( |\\t).+")
 
 (defvar *swm-ssh-default-term* "urxvtc")
+
+(defvar *swm-ssh-default-term-title-opt* "-T")
 
 (defun collect-hosts (&optional (ssh-known-hosts *swm-ssh-known-hosts-path*))
   (with-open-file (stream ssh-known-hosts :direction :input)
@@ -32,4 +35,12 @@
     (when entry
       (let ((host (car entry)))
         (stumpwm:run-shell-command
-         (format nil "~A -T ~A -e ssh ~A" *swm-ssh-default-term* host host))))))
+         (if *swm-ssh-default-term-title-opt*
+             (format nil "~A ~A ~A -e ssh ~A"
+                     *swm-ssh-default-term*
+                     *swm-ssh-default-term-title-opt*
+                     host
+                     host)
+             (format nil "~A -e ssh ~A"
+                     *swm-ssh-default-term*
+                     host)))))))


### PR DESCRIPTION
`-T` looks a universal option for `xterm` and `urxvtc`, but `sakura` requries `-t` (or `--title`) for example.
