### PR TITLE
Use absolute value of current_now

### DIFF
--- a/modeline/battery-portable/battery-portable.lisp
+++ b/modeline/battery-portable/battery-portable.lisp
@@ -209,7 +209,7 @@
                              (sysfs-int-field path "charge_now")))
                        (consumption ()
                          (or (sysfs-int-field path "power_now")
-                             (sysfs-int-field path "current_now")))
+                             (abs (sysfs-int-field path "current_now"))))
                        (capacity-native ()
                          (sysfs-int-field path "capacity"))
                        (capacity-calculate ()


### PR DESCRIPTION
It seems on my system that there has been a recent kernel change where `current_now` is reported negative when discharging, leading to no reported time remaining, only a dash; given this is only on certain kernel versions, it is perhaps better to just take the absolute value of `current_now` when calculating time remaining, just to remain compatible with both

# Checklist when contributing a new contrib

- [ ] Have you run `./update-readme.sh`?
