### PR TITLE
stumpish: Fix search for stumpwm PID if launched as stumpwm child pro…

### DIFF
--- a/util/stumpish/stumpish
+++ b/util/stumpish/stumpish
@@ -40,7 +40,9 @@ fi
 
 stumpwm_pid ()
 {
-    if command -v pgrep 2>&1 >/dev/null; then
+    if test $(uname -s) = "FreeBSD" && command -v pgrep 2>&1 > /dev/null; then
+        STUMPWM_PID=$(pgrep -a -u $(id -u) stumpwm)
+    elif command -v pgrep 2>&1 >/dev/null; then
         STUMPWM_PID=$(pgrep -u $(id -u) stumpwm)
     elif [ -d /proc ]; then
         # Go up the process chain until we locate StumpWM's process using


### PR DESCRIPTION
This pull request fixes one specific bug, when stumpish unable to find StumpWM PID if stumpish is executed from StumpWM.

# Description of fixed problem

I tried to use `stumpish` inside StumpWM like this, to use StumpWM input box as an askpass utility for `sudo`:

```lisp
(run-shell-command
 (format nil "~a sudo -A reboot"
         "SUDO_ASKPASS=/home/drag0n/.bin/askpass.sh"))
```

Suddenly, I found  that this code doesn't working. Further investigation showed me, that `pgrep -u $(id -u) stumpwm` didn't return any PID, although the StumpWM process exists in the `ps aux` output:

```
drag0n@freebsd:~ $ stumpish
StumpWM not found in the process tree, are you sure a graphical
session is running and StumpWM is your WM? If you think this is
a bug in stumpish, please report it.
drag0n@freebsd:~ $ pgrep -u $(id -u) stumpwm
drag0n@freebsd:~ $ ps aux | grep stumpwm
drag0n     74794   3.0  0.8 1307408 129300  -  Ss   16:49    0:14.76 /usr/local/bin/stumpwm
drag0n     30657   0.0  0.0   13916   2492  2  S+   16:53    0:00.00 grep stumpwm
```

# Problem's roots

In the FreeBSD the `pgrep` utility doesn't show itself or it's ancestors in the resulting output (see the `man 1 pgrep`). So, when I launch `stumpish` script inside StumpWM itself, then the StumpWM becomes the `stumpish` and a `pgrep` ancestor — and it's PID never appears in the `pgrep` result.

This behavior can be reproduced in the xterm launched from the StumpWM REPL:

```
41066  -  Is     0:00.01 |-- /usr/local/bin/xdm
42472  -  Ss     3:57.38 | |-- /usr/local/libexec/Xorg :0 -auth /var/db/xdm/authdir/authfiles/A:0-dwb0C1
78782  -  Is     0:00.11 | `-- xdm: :0 (xdm)
83552  -  Ss     2:15.28 |   `-- stumpwm
 3333  -  I      0:00.01 |     |-- emacsclient -a= -c -s /var/run/drag0n/emacs/main
30854  -  S      0:00.21 |     |-- xterm
31650  2  Ss     0:00.02 |     | `-- -sh (sh)
33058  2  R+     0:00.00 |     |   `-- pgrep
```

# Fix description

The FreeBSD's `pgrep` provides the `-a` key to show even the ancestors of `pgrep`. Sadly, in the Linux (according to the manpages in the Internet) the same argument is used to list full command line in the output.

So, I added a separate `if-then` clause with described FreeBSD specifics. I've used an `uname -s` command to check are we running under the FreeBSD.

There are also `uname -n` exists, which writes the system name (`freebsd`) in the output, but in Linux the same key is used to print network node name. If this name is matched with "freebsd", then my check will fail, so I've used `uname -s`.

OS type matched first, so if we running not under the FreeBSD, then the execution going to the default path (single check is `pgrep` exists or using the Linux-specific file from the `/proc` FS).

# Checklist when contributing a new contrib

- [x] Have you run `./update-readme.sh`?
