### PR TITLE
Fix Linux-specific line in the update-readme.sh script

### DIFF
--- a/update-readme.sh
+++ b/update-readme.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 sed '/# --/q' README.org > tmpReadme
 


### PR DESCRIPTION
# Problem description

Before this fix, the `./update-readme.sh` could not be executed in the FreeBSD. The `bash` shell doesn't installed in the `/bin/bash` because it is not included in the "base system" in the FreeBSD.

Since it is not included — it is installed in the `/usr/local/bin/bash`, so the mentioned script could not be launched. Instead, the error about not found command will be issued:

```
drag0n@freebsd:~/git_repos/stumpwm-contrib $ ./update-readme.sh
-sh: ./update-readme.sh: not found
```

# Proposed fix

To make the script not the Linux-specific, the shebang should looks like this:

```shell
#!/usr/bin/env bash
```

Not like this:

```shell
#!/bin/bash
```

The `env` will find the bash interpreter in the user's `PATH` environment variable.

*Note:* this fix will not work in some obscure systems without `/usr/bin/env`. This utility exists at least in the Linux (with `/usr/bin/env` as symbolic link to the `/bin/env` in some distributions) and *BSD systems.

# Checklist when contributing a new contrib

- [x] Have you run `./update-readme.sh`?
