### PR TITLE
Update swm-gaps to fix crash

### DIFF
--- a/util/swm-gaps/README.org
+++ b/util/swm-gaps/README.org
@@ -10,7 +10,7 @@ Credit goes to the original author.
 #+BEGIN_QUOTE
 This modifies StumpWM's internal functions ~maximize-window~ and ~neighbour~, so
 might not work as expected if those definitions change in the core. Currently
-works with ~v19.11~.
+works with ~v24.11~.
 #+END_QUOTE
 
 #+BEGIN_SRC common-lisp

--- a/util/swm-gaps/swm-gaps.lisp
+++ b/util/swm-gaps/swm-gaps.lisp
@@ -61,7 +61,7 @@ HEIGHT are subtracted."
       ;; otherwise stumpwm will crash. Also, only modify window dimensions
       ;; if needed (i.e. window at least fills frame minus gap).
       (when (and (< ow width)
-                 (>= width (- (frame-width frame) ow)))
+                 (>= width (- (stumpwm::frame-display-width (window-group win) frame) ow)))
         (setf width (- width ow)))
       (when (and (< oh height)
                  (>= height (- (stumpwm::frame-display-height (window-group win) frame) oh)))
@@ -87,7 +87,7 @@ HEIGHT are subtracted."
             (setf (xlib:drawable-width (window-parent win)) (window-width win)
                   (xlib:drawable-height (window-parent win)) (window-height win))
             (let ((frame (stumpwm::window-frame win)))
-              (setf (xlib:drawable-width (window-parent win)) (- (frame-width frame)
+              (setf (xlib:drawable-width (window-parent win)) (- (stumpwm::frame-display-width (window-group win) frame)
                                                                  (* 2 (xlib:drawable-border-width (window-parent win)))
                                                                  ow)
                     (xlib:drawable-height (window-parent win)) (- (stumpwm::frame-display-height (window-group win) frame)
@@ -100,6 +100,7 @@ HEIGHT are subtracted."
                                     wy
                                     (- (xlib:drawable-height (window-parent win)) height wy))
                               :cardinal 32))
+      (stumpwm::update-decoration win)
       (update-configuration win))))
 
 (defun reset-all-windows ()


### PR DESCRIPTION
After certain updates in stumpwm, the older code around frame parameters was not working, leading to crash. This patch fixes that and works without crash for current stumpwm `v24.11`.

Relevant issues: #276 